### PR TITLE
Adds AoA Voting

### DIFF
--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -24,6 +24,9 @@ type ExtendedAgent struct {
 
 	// debug
 	verboseLevel int
+
+	// AoA vote
+	AoARanking [6]int
 }
 
 type AgentConfig struct {
@@ -277,4 +280,10 @@ func (mi *ExtendedAgent) SendTeamFormingInvitation(agentIDs []uuid.UUID) {
 //   - teamID: The UUID of the team to assign to this agent
 func (mi *ExtendedAgent) SetTeamID(teamID uuid.UUID) {
 	mi.teamID = teamID
+}
+
+// In RunStartOfIteration, the server loops through each agent in each team
+// and sets the teams AoA by majority vote from the agents in that team.
+func (mi *ExtendedAgent) SetAgentAoA() {
+	mi.AoARanking = [0,0,0,0,0,0]
 }

--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -26,7 +26,7 @@ type ExtendedAgent struct {
 	verboseLevel int
 
 	// AoA vote
-	AoARanking [4]int
+	AoARanking []int
 }
 
 type AgentConfig struct {
@@ -36,10 +36,11 @@ type AgentConfig struct {
 
 func GetBaseAgents(funcs agent.IExposedServerFunctions[common.IExtendedAgent], configParam AgentConfig) *ExtendedAgent {
 	return &ExtendedAgent{
-		BaseAgent:    agent.CreateBaseAgent(funcs),
-		server:       funcs.(common.IServer), // Type assert the server functions to IServer interface
-		score:        configParam.InitScore,
-		verboseLevel: configParam.VerboseLevel,
+		BaseAgent:    	agent.CreateBaseAgent(funcs),
+		server:       	funcs.(common.IServer), // Type assert the server functions to IServer interface
+		score:        	configParam.InitScore,
+		verboseLevel: 	configParam.VerboseLevel,
+		AoARanking: 	[]int{3,2,1,0},
 	}
 }
 
@@ -284,6 +285,10 @@ func (mi *ExtendedAgent) SetTeamID(teamID uuid.UUID) {
 
 // In RunStartOfIteration, the server loops through each agent in each team
 // and sets the teams AoA by majority vote from the agents in that team.
-func (mi *ExtendedAgent) SetAgentAoA() {
-	mi.AoARanking = [3,2,1,0] // set constant vote for now
+func (mi *ExtendedAgent) SetAoARanking(Preferences []int) {
+	mi.AoARanking = Preferences
+}
+
+func (mi *ExtendedAgent) GetAoARanking() []int {
+	return mi.AoARanking
 }

--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -26,7 +26,7 @@ type ExtendedAgent struct {
 	verboseLevel int
 
 	// AoA vote
-	AoARanking [6]int
+	AoARanking [4]int
 }
 
 type AgentConfig struct {
@@ -285,5 +285,5 @@ func (mi *ExtendedAgent) SetTeamID(teamID uuid.UUID) {
 // In RunStartOfIteration, the server loops through each agent in each team
 // and sets the teams AoA by majority vote from the agents in that team.
 func (mi *ExtendedAgent) SetAgentAoA() {
-	mi.AoARanking = [0,0,0,0,0,0]
+	mi.AoARanking = [3,2,1,0] // set constant vote for now
 }

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -32,4 +32,6 @@ type IExtendedAgent interface {
 	// Info
 	GetExposedInfo() ExposedAgentInfo
 	LogSelfInfo()
+	GetAoARanking() []int
+	SetAoARanking(Preferences []int)
 }

--- a/common/team.go
+++ b/common/team.go
@@ -3,22 +3,22 @@ package common
 import "github.com/google/uuid"
 
 type Team struct {
-	TeamID     uuid.UUID
-	CommonPool int
-	Agents     []uuid.UUID
+	TeamID     	uuid.UUID
+	CommonPool 	int
+	Agents     	[]uuid.UUID
 	AuditResult map[uuid.UUID]bool // Default is false, which means if false then there is no deferral
-	ArticlesOfAssociation *ArticlesOfAssociation
+	TeamAoA 	*ArticlesOfAssociation
 }
 
 // constructor: NewTeam creates a new Team with a unique TeamID and initializes other fields as blank.
 func NewTeam() Team {
 	aoa := CreateArticlesOfAssociation(CreateFixedContributionRule(10), CreateFixedWithdrawalRule(10), CreateFixedAuditCost(10), CreateFixedPunishment(10))
 	return Team{
-		TeamID:     uuid.New(),             // Generate a unique TeamID
-		CommonPool: 0,                      // Initialize commonPool to 0
-		Agents:     []uuid.UUID{},          // Initialize an empty slice of agent UUIDs
-		AuditResult: map[uuid.UUID]bool{},  // Initialize an empty map of agentID -> bool
-		ArticlesOfAssociation: aoa,         // Initialize strategy as 0
+		TeamID:     	uuid.New(),             // Generate a unique TeamID
+		CommonPool: 	0,                      // Initialize commonPool to 0
+		Agents:     	[]uuid.UUID{},          // Initialize an empty slice of agent UUIDs
+		AuditResult:	map[uuid.UUID]bool{},  // Initialize an empty map of agentID -> bool
+		TeamAoA: aoa,   // Initialize strategy as 0
 	}
 }
 

--- a/common/team.go
+++ b/common/team.go
@@ -23,14 +23,14 @@ func NewTeam() Team {
 }
 
 func (team *Team) SetContributionResult(agentID uuid.UUID, agentScore int, agentActualContribution int) {
-	agentExpectedContribution := team.ArticlesOfAssociation.contributionRule.GetExpectedContributionAmount(agentScore)
+	agentExpectedContribution := team.TeamAoA.contributionRule.GetExpectedContributionAmount(agentScore)
 	if agentActualContribution != agentExpectedContribution {
 		team.AuditResult[agentID] = team.AuditResult[agentID] || true // There is a deferral
 	}
 }
 
 func (team *Team) SetWithdrawalResult(agentID uuid.UUID, agentScore int, agentActualWithdrawal int) {
-	agentExpectedWithdrawal := team.ArticlesOfAssociation.withdrawalRule.GetExpectedWithdrawalAmount(agentScore)
+	agentExpectedWithdrawal := team.TeamAoA.withdrawalRule.GetExpectedWithdrawalAmount(agentScore)
 	if agentActualWithdrawal != agentExpectedWithdrawal {
 		team.AuditResult[agentID] = team.AuditResult[agentID] || true // There is a deferral
 	}

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -45,6 +45,33 @@ func (cs *EnvironmentServer) RunStartOfIteration(int) {
 	cs.CreateNewRoundScoreThreshold()
 	// start team forming
 
+	// take votes at team level and allocate Strategy.
+	cs.AllocateAoAs()
+}
+
+// Allocate AoA based on team votes;
+// for each member in team, count vote for AoA and then take majority (?) vote
+// assign majority vote back to team struct (team.Strategy)
+func (cs *EnvironmentServer) AllocateAoAs(){
+	// once teams assigned, gather AoA votes from each agent.
+	for _, team := range cs.teams {
+		// ranking cache for each team.
+		voteSum = []
+		for _, agent := range team.Agents {
+			for aoa, vote := range agent.AoARanking{}
+			// accumulate vote from each agent in team
+			voteSum[aoa] += vote
+		}
+		// logic to check largest
+		maxVote = 0
+		for _, sum := range voteSum {
+			if sum > maxVote{
+				maxVote = sum
+			}
+		}
+		// update teams strategy. 
+		team.Strategy = maxVote
+	}
 }
 
 func (cs *EnvironmentServer) RunEndOfIteration(int) {

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -25,7 +25,7 @@ type EnvironmentServer struct {
 
 
 	// set of options for team strategies (agents rank these options)
-	aoaMenu  			[]ArticlesOfAssociation
+	aoaMenu  			[]*common.ArticlesOfAssociation
 }
 
 // overrides that requires implementation
@@ -60,15 +60,15 @@ func (cs *EnvironmentServer) AllocateAoAs(){
 	// once teams assigned, gather AoA votes from each agent.
 	for _, team := range cs.teams {
 		// ranking cache for each team.
-		voteSum = [0,0,0,0]
+		var voteSum = []int{0,0,0,0}
 		for _, agent := range team.Agents {
-			for aoa, vote := range agent.AoARanking{}
-			// accumulate vote from each agent in team
-			voteSum[aoa] += vote
+			for aoa, vote := range cs.GetAgentMap()[agent].GetAoARanking() {
+				voteSum[aoa] += vote
+			}
 		}
 		// logic to check largest
-		currentMax = 0
-		preference = 0
+		var currentMax = 0
+		var preference = 0
 		for aoa, voteCount := range voteSum{
 			if voteCount > currentMax{
 				currentMax = voteCount
@@ -77,7 +77,7 @@ func (cs *EnvironmentServer) AllocateAoAs(){
 		}
 
 		// update teams strategy. 
-		team.TeamAoA = aoaMenu[preference]
+		team.TeamAoA = cs.aoaMenu[preference]
 	}
 }
 
@@ -109,33 +109,35 @@ func MakeEnvServer(numAgent int, iterations int, turns int, maxDuration time.Dur
 		serv.AddAgent(agent)
 	}
 
+	serv.aoaMenu = []*common.ArticlesOfAssociation{nil, nil, nil, nil}
+
 	// for now, menu just has 4 choices of AoA. TBC.
-	aoaMenu[0] = CreateArticlesOfAssociation(
-		CreateFixedContributionRule(10),
-		CreateFixedWithdrawalRule(10),
-		CreateFixedAuditCost(10),
-		CreateFixedPunishment(10),
+	serv.aoaMenu[0] = common.CreateArticlesOfAssociation(
+		common.CreateFixedContributionRule(10),
+		common.CreateFixedWithdrawalRule(10),
+		common.CreateFixedAuditCost(10),
+		common.CreateFixedPunishment(10),
 	)
 
-	aoaMenu[1] = CreateArticlesOfAssociation(
-		CreateFixedContributionRule(20),
-		CreateFixedWithdrawalRule(20),
-		CreateFixedAuditCost(20),
-		CreateFixedPunishment(20),
+	serv.aoaMenu[1] = common.CreateArticlesOfAssociation(
+		common.CreateFixedContributionRule(20),
+		common.CreateFixedWithdrawalRule(20),
+		common.CreateFixedAuditCost(20),
+		common.CreateFixedPunishment(20),
 	)
 
-	aoaMenu[2] = CreateArticlesOfAssociation(
-		CreateFixedContributionRule(30),
-		CreateFixedWithdrawalRule(30),
-		CreateFixedAuditCost(30),
-		CreateFixedPunishment(30),
+	serv.aoaMenu[2] = common.CreateArticlesOfAssociation(
+		common.CreateFixedContributionRule(30),
+		common.CreateFixedWithdrawalRule(30),
+		common.CreateFixedAuditCost(30),
+		common.CreateFixedPunishment(30),
 	)
 
-	aoaMenu[3] = CreateArticlesOfAssociation(
-		CreateFixedContributionRule(40),
-		CreateFixedWithdrawalRule(40),
-		CreateFixedAuditCost(40),
-		CreateFixedPunishment(40),
+	serv.aoaMenu[3] = common.CreateArticlesOfAssociation(
+		common.CreateFixedContributionRule(40),
+		common.CreateFixedWithdrawalRule(40),
+		common.CreateFixedAuditCost(40),
+		common.CreateFixedPunishment(40),
 	)
 
 


### PR DESCRIPTION
This PR allows agents to specify a preference of AoAs from an AoA menu stored on the server. The server then collects votes from each agent in each team, and updates the team's preference.