### PR TITLE
Fix dead agent segmentation issue by ensuring removal from teams and handling null pointers

### DIFF
--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -30,6 +30,9 @@ type ExtendedAgent struct {
 
 	// AoA vote
 	AoARanking []int
+
+	LastTeamID uuid.UUID // Tracks the last team the agent was part of
+
 }
 
 type AgentConfig struct {
@@ -39,11 +42,11 @@ type AgentConfig struct {
 
 func GetBaseAgents(funcs agent.IExposedServerFunctions[common.IExtendedAgent], configParam AgentConfig) *ExtendedAgent {
 	return &ExtendedAgent{
-		BaseAgent:    	agent.CreateBaseAgent(funcs),
-		server:       	funcs.(common.IServer), // Type assert the server functions to IServer interface
-		score:        	configParam.InitScore,
-		verboseLevel: 	configParam.VerboseLevel,
-		AoARanking: 	[]int{3,2,1,0},
+		BaseAgent:    agent.CreateBaseAgent(funcs),
+		server:       funcs.(common.IServer), // Type assert the server functions to IServer interface
+		score:        configParam.InitScore,
+		verboseLevel: configParam.VerboseLevel,
+		AoARanking:   []int{3, 2, 1, 0},
 	}
 }
 
@@ -300,6 +303,8 @@ func (mi *ExtendedAgent) SendTeamFormingInvitation(agentIDs []uuid.UUID) {
 // Parameters:
 //   - teamID: The UUID of the team to assign to this agent
 func (mi *ExtendedAgent) SetTeamID(teamID uuid.UUID) {
+	// Store the previous team ID
+	mi.LastTeamID = mi.teamID
 	mi.teamID = teamID
 }
 
@@ -312,7 +317,7 @@ func (mi *ExtendedAgent) SetAoARanking(Preferences []int) {
 func (mi *ExtendedAgent) GetAoARanking() []int {
 	return mi.AoARanking
 }
-  
+
 func (mi *ExtendedAgent) SetCommonPoolValue(poolValue int) {
 	mi.commonPoolValue = poolValue
 	fmt.Printf("setting common pool to %d\n", poolValue)

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -16,16 +16,15 @@ import (
 type EnvironmentServer struct {
 	*server.BaseServer[common.IExtendedAgent]
 
-	teamsMutex    		sync.RWMutex
-	agentInfoList 		[]common.ExposedAgentInfo
-	teams         		map[uuid.UUID]common.Team
+	teamsMutex    sync.RWMutex
+	agentInfoList []common.ExposedAgentInfo
+	teams         map[uuid.UUID]common.Team
 
 	roundScoreThreshold int
 	deadAgents          []common.IExtendedAgent
 
-
 	// set of options for team strategies (agents rank these options)
-	aoaMenu  			[]*common.ArticlesOfAssociation
+	aoaMenu []*common.ArticlesOfAssociation
 }
 
 // overrides that requires implementation
@@ -70,28 +69,38 @@ func (cs *EnvironmentServer) RunStartOfIteration(int) {
 // Allocate AoA based on team votes;
 // for each member in team, count vote for AoA and then take majority (?) vote
 // assign majority vote back to team struct (team.Strategy)
-func (cs *EnvironmentServer) AllocateAoAs(){
-	// once teams assigned, gather AoA votes from each agent.
+func (cs *EnvironmentServer) AllocateAoAs() {
+	// Iterate over each team
 	for _, team := range cs.teams {
-		// ranking cache for each team.
-		var voteSum = []int{0,0,0,0}
-		for _, agent := range team.Agents {
-			for aoa, vote := range cs.GetAgentMap()[agent].GetAoARanking() {
+		// Ranking cache for the team's votes
+		voteSum := []int{0, 0, 0, 0}
+
+		// Iterate over the agents in the team
+		for _, agentID := range team.Agents {
+			// Skip dead agents
+			if cs.IsAgentDead(agentID) {
+				continue
+			}
+
+			// Get the agent's AoA ranking and add their votes
+			for aoa, vote := range cs.GetAgentMap()[agentID].GetAoARanking() {
 				voteSum[aoa] += vote
 			}
 		}
-		// logic to check largest
-		var currentMax = 0
-		var preference = 0
-		for aoa, voteCount := range voteSum{
-			if voteCount > currentMax{
+
+		// Determine the preferred AoA based on the majority vote
+		currentMax := 0
+		preference := 0
+		for aoa, voteCount := range voteSum {
+			if voteCount > currentMax {
 				currentMax = voteCount
 				preference = aoa
 			}
 		}
 
-		// update teams strategy. 
+		// Update the team's strategy
 		team.TeamAoA = cs.aoaMenu[preference]
+		cs.teams[team.TeamID] = team
 	}
 }
 
@@ -154,7 +163,6 @@ func MakeEnvServer(numAgent int, iterations int, turns int, maxDuration time.Dur
 		common.CreateFixedPunishment(40),
 	)
 
-
 	return serv
 }
 
@@ -175,11 +183,15 @@ func (cs *EnvironmentServer) LogTeamStatus() {
 	for _, team := range cs.teams {
 		fmt.Printf("Team %v: %v\n", team.TeamID, team.Agents)
 	}
-	// log agents that have no team
+	// Log agents with no team
 	for _, agent := range cs.GetAgentMap() {
 		if agent.GetTeamID() == uuid.Nil {
 			fmt.Printf("Agent %v has no team\n", agent.GetID())
 		}
+	}
+	// Log dead agents
+	for _, agent := range cs.deadAgents {
+		fmt.Printf("Agent %v is dead, last team: %v\n", agent.GetID(), agent.(*agents.ExtendedAgent).LastTeamID)
 	}
 }
 
@@ -211,8 +223,27 @@ func (cs *EnvironmentServer) KillAgentBelowThreshold(agentID uuid.UUID) int {
 
 // kill agent
 func (cs *EnvironmentServer) KillAgent(agentID uuid.UUID) {
-	cs.deadAgents = append(cs.deadAgents, cs.GetAgentMap()[agentID])
-	cs.RemoveAgent(cs.GetAgentMap()[agentID])
+	agent := cs.GetAgentMap()[agentID]
+
+	// Remove the agent from the team
+	if teamID := agent.GetTeamID(); teamID != uuid.Nil {
+		cs.teamsMutex.Lock()
+		team := cs.teams[teamID]
+		for i, id := range team.Agents {
+			if id == agentID {
+				// Remove agent from the team
+				team.Agents = append(team.Agents[:i], team.Agents[i+1:]...)
+				cs.teams[teamID] = team
+				break
+			}
+		}
+		cs.teamsMutex.Unlock()
+	}
+
+	// Add the agent to the dead agent list and remove it from the server's agent map
+	cs.deadAgents = append(cs.deadAgents, agent)
+	cs.RemoveAgent(agent)
+
 	fmt.Printf("[server] Agent %v killed\n", agentID)
 }
 


### PR DESCRIPTION
Fixed segmentation fault caused by dead agents remaining in team references. Updated logic to remove agents from teams upon death, skip dead agents during AoA allocation, and track their last team for historical purposes.
