### PR TITLE
Bug Fix in LogTeamStatus

### DIFF
--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -53,6 +53,10 @@ func (mi *ExtendedAgent) GetTeamID() uuid.UUID {
 	return mi.teamID
 }
 
+func (mi *ExtendedAgent) GetLastTeamID() uuid.UUID {
+	return mi.LastTeamID
+}
+
 // Can only be called by the server (otherwise other agents will see their true score)
 func (mi *ExtendedAgent) GetTrueScore() int {
 	return mi.score

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -10,6 +10,7 @@ type IExtendedAgent interface {
 
 	// Getters
 	GetTeamID() uuid.UUID
+	GetLastTeamID() uuid.UUID
 	GetTrueScore() int
 
 	// Setters

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -205,19 +205,19 @@ func (cs *EnvironmentServer) LogAgentStatus() {
 
 // pretty logging to show all team status
 func (cs *EnvironmentServer) LogTeamStatus() {
-	for _, team := range cs.teams {
-		fmt.Printf("Team %v: %v\n", team.TeamID, team.Agents)
-	}
-	// Log agents with no team
-	for _, agent := range cs.GetAgentMap() {
-		if agent.GetTeamID() == uuid.Nil {
-			fmt.Printf("Agent %v has no team\n", agent.GetID())
-		}
-	}
-	// Log dead agents
-	for _, agent := range cs.deadAgents {
-		fmt.Printf("Agent %v is dead, last team: %v\n", agent.GetID(), agent.(*agents.ExtendedAgent).LastTeamID)
-	}
+    for _, team := range cs.teams {
+        fmt.Printf("Team %v: %v\n", team.TeamID, team.Agents)
+    }
+    // Log agents with no team
+    for _, agent := range cs.GetAgentMap() {
+        if agent.GetTeamID() == uuid.Nil {
+            fmt.Printf("Agent %v has no team\n", agent.GetID())
+        }
+    }
+    // Log dead agents
+    for _, agent := range cs.deadAgents {
+		fmt.Printf("Agent %v is dead, last team: %v\n", agent.GetID(), agent.GetLastTeamID())
+    }
 }
 
 func (cs *EnvironmentServer) UpdateAndGetAgentExposedInfo() []common.ExposedAgentInfo {


### PR DESCRIPTION
**Add GetLastTeamID() function for Extended Agent**

Bug Fix:
- fixes panic when checking lastTeamID on any agent embedding ExtendedAgent

```
panic: interface conversion: common.IExtendedAgent is *agents.MI_256_v1, not *agents.ExtendedAgent

goroutine 1 [running]:
SOMAS_Extended/server.(*EnvironmentServer).LogTeamStatus(0x1400011c000)
```