### PR TITLE
Moved AoA into common to avoid cyclic dependancies

### DIFF
--- a/ArticlesOfAssociation/Team3AoA.go
+++ b/ArticlesOfAssociation/Team3AoA.go
@@ -1,1 +1,0 @@
-package aoa

--- a/ArticlesOfAssociation/Team4AoA.go
+++ b/ArticlesOfAssociation/Team4AoA.go
@@ -1,1 +1,0 @@
-package aoa

--- a/ArticlesOfAssociation/Team5AoA.go
+++ b/ArticlesOfAssociation/Team5AoA.go
@@ -1,1 +1,0 @@
-package aoa

--- a/ArticlesOfAssociation/Team6AoA.go
+++ b/ArticlesOfAssociation/Team6AoA.go
@@ -1,1 +1,0 @@
-package aoa

--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -8,7 +8,7 @@ import (
 
 	common "SOMAS_Extended/common"
 
-	// TODO: 
+	// TODO:
 
 	"github.com/MattSScott/basePlatformSOMAS/v2/pkg/agent"
 	"github.com/MattSScott/basePlatformSOMAS/v2/pkg/message"

--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -8,8 +8,7 @@ import (
 
 	common "SOMAS_Extended/common"
 
-	// TODO: S
-	aoa "SOMAS_Extended/ArticlesOfAssociation"
+	// TODO: 
 
 	"github.com/MattSScott/basePlatformSOMAS/v2/pkg/agent"
 	"github.com/MattSScott/basePlatformSOMAS/v2/pkg/message"
@@ -232,16 +231,16 @@ func (mi *ExtendedAgent) LogSelfInfo() {
 // 0: No preference
 // 1: Prefer audit
 // -1: Prefer no audit
-func (mi *ExtendedAgent) GetContributionAuditVote() aoa.Vote {
-	return aoa.CreateVote(0, mi.GetID(), uuid.Nil)
+func (mi *ExtendedAgent) GetContributionAuditVote() common.Vote {
+	return common.CreateVote(0, mi.GetID(), uuid.Nil)
 }
 
 // Agent returns their preference for an audit on withdrawal
 // 0: No preference
 // 1: Prefer audit
 // -1: Prefer no audit
-func (mi *ExtendedAgent) GetWithdrawalAuditVote() aoa.Vote {
-	return aoa.CreateVote(0, mi.GetID(), uuid.Nil)
+func (mi *ExtendedAgent) GetWithdrawalAuditVote() common.Vote {
+	return common.CreateVote(0, mi.GetID(), uuid.Nil)
 }
 
 func (mi *ExtendedAgent) SetAgentContributionAuditResult(agentID uuid.UUID, result bool) {}

--- a/common/ArticlesOfAssociation.go
+++ b/common/ArticlesOfAssociation.go
@@ -1,4 +1,4 @@
-package aoa
+package common
 
 import "github.com/google/uuid"
 

--- a/common/FixedAoA.go
+++ b/common/FixedAoA.go
@@ -1,4 +1,4 @@
-package aoa
+package common
 
 import (
 	"github.com/google/uuid"

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	aoa "SOMAS_Extended/ArticlesOfAssociation"
 	"github.com/MattSScott/basePlatformSOMAS/v2/pkg/agent"
 	"github.com/google/uuid"
 )
@@ -48,6 +47,6 @@ type IExtendedAgent interface {
 	LogSelfInfo()
 	GetAoARanking() []int
 	SetAoARanking(Preferences []int)
-	GetContributionAuditVote() aoa.Vote
-	GetWithdrawalAuditVote() aoa.Vote
+	GetContributionAuditVote() Vote
+	GetWithdrawalAuditVote() Vote
 }

--- a/common/Team1AoA.go
+++ b/common/Team1AoA.go
@@ -1,4 +1,4 @@
-package aoa
+package common
 
 import (
 	"container/list"

--- a/common/Team2AoA.go
+++ b/common/Team2AoA.go
@@ -1,4 +1,4 @@
-package aoa
+package common
 
 // import "github.com/google/uuid"
 import (

--- a/common/Team3AoA.go
+++ b/common/Team3AoA.go
@@ -1,0 +1,1 @@
+package common

--- a/common/Team4AoA.go
+++ b/common/Team4AoA.go
@@ -1,0 +1,1 @@
+package common

--- a/common/Team5AoA.go
+++ b/common/Team5AoA.go
@@ -1,0 +1,1 @@
+package common

--- a/common/Team6AoA.go
+++ b/common/Team6AoA.go
@@ -1,0 +1,1 @@
+package common

--- a/common/team.go
+++ b/common/team.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	// TODO: should it be structured this way?
-	aoa "SOMAS_Extended/ArticlesOfAssociation"
 
 	"github.com/google/uuid"
 )
@@ -10,7 +9,7 @@ import (
 type Team struct {
 	TeamID  uuid.UUID
 	Agents  []uuid.UUID
-	TeamAoA aoa.IArticlesOfAssociation
+	TeamAoA IArticlesOfAssociation
 
 	commonPool int
 }
@@ -25,7 +24,7 @@ func (team *Team) SetCommonPool(amount int) {
 
 // constructor: NewTeam creates a new Team with a unique TeamID and initializes other fields as blank.
 func NewTeam(teamID uuid.UUID) *Team {
-	teamAoA := aoa.CreateFixedAoA()
+	teamAoA := CreateFixedAoA()
 	return &Team{
 		TeamID:     teamID,        // Generate a unique TeamID
 		commonPool: 0,             // Initialize commonPool to 0

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -1,9 +1,8 @@
 package environmentServer
 
 import (
-	aoa "SOMAS_Extended/ArticlesOfAssociation"
 	"SOMAS_Extended/agents"
-	"SOMAS_Extended/common"
+	common "SOMAS_Extended/common"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -25,7 +24,7 @@ type EnvironmentServer struct {
 	deadAgents          []common.IExtendedAgent
 
 	// set of options for team strategies (agents rank these options)
-	aoaMenu []aoa.IArticlesOfAssociation
+	aoaMenu []common.IArticlesOfAssociation
 }
 
 func (cs *EnvironmentServer) RunTurn(i, j int) {
@@ -62,7 +61,7 @@ func (cs *EnvironmentServer) RunTurn(i, j int) {
 		team.TeamAoA.RunAoAStuff()
 
 		// Initiate Contribution Audit vote
-		contributionAuditVotes := []aoa.Vote{}
+		contributionAuditVotes := []common.Vote{}
 		for _, agentID := range team.Agents {
 			agent := cs.GetAgentMap()[agentID]
 			vote := agent.GetContributionAuditVote()
@@ -104,7 +103,7 @@ func (cs *EnvironmentServer) RunTurn(i, j int) {
 		}
 
 		// Initiate Withdrawal Audit vote
-		withdrawalAuditVotes := []aoa.Vote{}
+		withdrawalAuditVotes := []common.Vote{}
 		for _, agentID := range team.Agents {
 			agent := cs.GetAgentMap()[agentID]
 			vote := agent.GetWithdrawalAuditVote()
@@ -225,16 +224,16 @@ func MakeEnvServer(numAgent int, iterations int, turns int, maxDuration time.Dur
 		// TEAM 6
 	}
 
-	serv.aoaMenu = make([]aoa.IArticlesOfAssociation, 4)
+	serv.aoaMenu = make([]common.IArticlesOfAssociation, 4)
 
 	// for now, menu just has 4 choices of AoA. TBC.
-	serv.aoaMenu[0] = aoa.CreateFixedAoA()
+	serv.aoaMenu[0] = common.CreateFixedAoA()
 
-	serv.aoaMenu[1] = aoa.CreateFixedAoA()
+	serv.aoaMenu[1] = common.CreateFixedAoA()
 
-	serv.aoaMenu[2] = aoa.CreateFixedAoA()
+	serv.aoaMenu[2] = common.CreateFixedAoA()
 
-	serv.aoaMenu[3] = aoa.CreateFixedAoA()
+	serv.aoaMenu[3] = common.CreateFixedAoA()
 
 	return serv
 }


### PR DESCRIPTION
This pull request includes major changes to the package structure and refactoring of code to improve consistency and maintainability. The primary focus is on moving files related to Articles of Association (AoA) from the `ArticlesOfAssociation` package to the `common` package and updating the corresponding references throughout the codebase.
