### PR TITLE
Dice Roll Override Functionality

### DIFF
--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -221,6 +221,16 @@ func (mi *ExtendedAgent) DecideWithdrawal() int {
 	}
 }
 
+/*
+Provide agentId for memory, current accumulated score
+(to see if above or below predicted threshold for common pool contribution)
+And previous roll in case relevant
+*/
+func (mi *ExtendedAgent) StickOrAgainFor(agentId uuid.UUID, accumulatedScore int, prevRoll int) int {
+	// random chance, to simulate what is already implemented
+	return rand.Intn(2)
+}
+
 // dev function
 func (mi *ExtendedAgent) LogSelfInfo() {
 	fmt.Printf("[Agent %s] score: %v\n", mi.GetID(), mi.score)

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -35,6 +35,7 @@ type IExtendedAgent interface {
 	StickOrAgain() bool
 	DecideContribution() int
 	DecideWithdrawal() int
+	StickOrAgainFor(agentId uuid.UUID, accumulatedScore int, prevRoll int) int
 
 	// Messaging functions
 	HandleTeamFormationMessage(msg *TeamFormationMessage)

--- a/common/Team2AoA.go
+++ b/common/Team2AoA.go
@@ -58,6 +58,9 @@ func (t *Team2AoA) GetContributionAuditResult(agentId uuid.UUID) bool {
 func (t *Team2AoA) SetContributionAuditResult(agentId uuid.UUID, agentScore int, agentActualContribution int, agentStatedContribution int) {
 	// ignore agentStatedContribution
 	// check if agent actually contributed it's entire score
+	if t.AuditMap[agentId] == nil {
+		t.AuditMap[agentId] = NewAuditQueue(5)
+	}
 	t.AuditMap[agentId].AddToQueue(agentActualContribution != agentScore)
 }
 
@@ -73,6 +76,9 @@ func (t *Team2AoA) GetExpectedWithdrawal(agentId uuid.UUID, agentScore int, comm
 }
 
 func (t *Team2AoA) SetWithdrawalAuditResult(agentId uuid.UUID, agentScore int, agentActualWithdrawal int, agentStatedWithdrawal int, commonPool int) {
+	if t.AuditMap[agentId] == nil {
+		t.AuditMap[agentId] = NewAuditQueue(5)
+	}
 	if agentId == t.Leader {
 		t.AuditMap[agentId].AddToQueue(float64(agentScore)*0.25 != float64(agentActualWithdrawal))
 	} else {
@@ -106,7 +112,7 @@ func (t *Team2AoA) GetVoteResult(votes []Vote) uuid.UUID {
 
 func (t *Team2AoA) GetWithdrawalOrder(agentIDs []uuid.UUID) []uuid.UUID {
 	// Seed the random number generator to ensure different shuffles each time
-	rand.Seed(time.Now().UnixNano())
+	rand.NewSource(time.Now().UnixNano())
 
 	// Create a copy of the agentIDs to avoid modifying the original list
 	shuffledAgents := make([]uuid.UUID, len(agentIDs))
@@ -122,7 +128,7 @@ func (t *Team2AoA) GetWithdrawalOrder(agentIDs []uuid.UUID) []uuid.UUID {
 
 func (t *Team2AoA) RunAoAStuff() {}
 
-func CreateTeam2AoA() IArticlesOfAssociation {
+func CreateTeam2AoA(auditDuration int) IArticlesOfAssociation {
 	return &Team2AoA{
 		AuditMap:   make(map[uuid.UUID]*AuditQueue),
 		OffenceMap: make(map[uuid.UUID]int),

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -42,6 +42,9 @@ func (cs *EnvironmentServer) RunTurn(i, j int) {
 			if agent.GetTeamID() == uuid.Nil || cs.IsAgentDead(agentID) {
 				continue
 			}
+			// Override agent rolls for testing purposes
+			// agentList := []uuid.UUID{agentID}
+			// cs.OverrideAgentRolls(agentID, agentList, 1)
 			agent.StartRollingDice(agent)
 			agentActualContribution := agent.GetActualContribution(agent)
 			agentContributionsTotal += agentActualContribution
@@ -432,4 +435,62 @@ func (cs *EnvironmentServer) GetTeam(agentID uuid.UUID) *common.Team {
 	// cs.teamsMutex.RLock()
 	// defer cs.teamsMutex.RUnlock()
 	return cs.teams[cs.GetAgentMap()[agentID].GetTeamID()]
+}
+
+// Possibly needs to look at what team/AoA is being used to tally up the votes
+func (cs *EnvironmentServer) OverrideAgentRolls(agentId uuid.UUID, controllerIds []uuid.UUID, stickThreshold int) {
+	controlled := cs.GetAgentMap()[agentId]
+	currentScore := controlled.GetTrueScore()
+
+	accumulatedScore := 0
+	rounds := 1
+	prevRoll := -1
+
+	rollingComplete := false
+
+	for !rollingComplete {
+		// AoAs can change how many stick decisions are needed here
+		numStickDecisions := 0
+		// The agents responsible for making the stick or again decision
+		for _, controllerId := range controllerIds {
+			controller := cs.GetAgentMap()[controllerId]
+			numStickDecisions += controller.StickOrAgainFor(agentId, accumulatedScore, prevRoll)
+		}
+
+		if numStickDecisions >= stickThreshold {
+			rollingComplete = true
+			fmt.Printf("%s decided to [STICK], score accumulated: %v", agentId, accumulatedScore)
+			break
+		}
+
+		if rounds > 1 {
+			fmt.Printf("%s decided to [CONTINUE ROLLING], previous roll: %v", agentId, prevRoll)
+		}
+
+		currentRoll := generateScore()
+		fmt.Printf("%s rolled: %v\n this turn", agentId, currentRoll)
+		if currentRoll <= prevRoll {
+			// Gone bust, so reset the accumulated score and break out of the loop
+			accumulatedScore = 0
+			fmt.Printf("%s **[HAS GONE BUST!]** round: %v, current score: %v\n", agentId, rounds, currentScore)
+			break
+		}
+
+		accumulatedScore += currentRoll
+		prevRoll = currentRoll
+		rounds++
+	}
+	// In case the agent has gone bust, this does nothing
+	controlled.SetTrueScore(currentScore + accumulatedScore)
+	// Log the updated score
+	fmt.Printf("%s turn score: %v, total score: %v\n", agentId, accumulatedScore, controlled.GetTrueScore())
+}
+
+func generateScore() int {
+	rand.New(rand.NewSource(time.Now().UnixNano()))
+	score := 0
+	for i := 0; i < 3; i++ {
+		score += rand.Intn(6) + 1
+	}
+	return score
 }


### PR DESCRIPTION
Adds functionality to enable the server to defer to other agents when making the dice roll decision. This could be used in an AoA, could just be a punishment as well. Gives more control to the server. Handles #33 as well.