### PR TITLE
Allow Orphans to Rejoin Teams at the start of a turn (no messages)

### DIFF
--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -451,3 +451,14 @@ func (mi *ExtendedAgent) SetAoARanking(Preferences []int) {
 func (mi *ExtendedAgent) GetAoARanking() []int {
 	return mi.AoARanking
 }
+
+/*
+* Decide whether to allow an agent into the team. This will be part of the group
+* strategy, and should be implemented by individual groups. During testing this
+* function is mocked. 
+*/
+func (mi *ExtendedAgent) VoteOnAgentEntry(candidateID uuid.UUID) bool {
+    // TODO: Implement strategy for accepting an agent into the team. 
+    // Return true to accept them, false to not accept them. 
+    return true
+}

--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -29,6 +29,12 @@ type ExtendedAgent struct {
 	// AoA vote
 	AoARanking []int
 
+    /* Team Ranking - Tracks the teams that the agent would like to join (if /
+    * when it is an orphan) in order of preference. Lowest index = highest
+    * priority. If this is empty, the server will not attempt to allocate the
+    * orphan to a team. */
+    TeamRanking []uuid.UUID 
+
 	LastTeamID uuid.UUID // Tracks the last team the agent was part of
 }
 
@@ -460,4 +466,9 @@ func (mi *ExtendedAgent) VoteOnAgentEntry(candidateID uuid.UUID) bool {
 	// TODO: Implement strategy for accepting an agent into the team.
 	// Return true to accept them, false to not accept them.
 	return true
+}
+
+// Return the team ranking
+func (mi *ExtendedAgent) GetTeamRanking() []uuid.UUID {
+	return mi.TeamRanking
 }

--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -29,11 +29,11 @@ type ExtendedAgent struct {
 	// AoA vote
 	AoARanking []int
 
-    /* Team Ranking - Tracks the teams that the agent would like to join (if /
-    * when it is an orphan) in order of preference. Lowest index = highest
-    * priority. If this is empty, the server will not attempt to allocate the
-    * orphan to a team. */
-    TeamRanking []uuid.UUID 
+	/* Team Ranking - Tracks the teams that the agent would like to join (if /
+	 * when it is an orphan) in order of preference. Lowest index = highest
+	 * priority. If this is empty, the server will not attempt to allocate the
+	 * orphan to a team. */
+	TeamRanking []uuid.UUID
 
 	LastTeamID uuid.UUID // Tracks the last team the agent was part of
 }
@@ -50,6 +50,7 @@ func GetBaseAgents(funcs agent.IExposedServerFunctions[common.IExtendedAgent], c
 		score:        configParam.InitScore,
 		verboseLevel: configParam.VerboseLevel,
 		AoARanking:   []int{3, 2, 1, 0},
+		TeamRanking:  []uuid.UUID{},
 	}
 }
 
@@ -471,4 +472,11 @@ func (mi *ExtendedAgent) VoteOnAgentEntry(candidateID uuid.UUID) bool {
 // Return the team ranking
 func (mi *ExtendedAgent) GetTeamRanking() []uuid.UUID {
 	return mi.TeamRanking
+}
+
+// Set the team ranking of which teams this agent would like to join - lower
+// index = higher priority. This can be updated as the game goes on, the server
+// will only act on this information when the agent is orphaned.
+func (mi *ExtendedAgent) SetTeamRanking(teamRanking []uuid.UUID) {
+	mi.TeamRanking = teamRanking
 }

--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -455,10 +455,10 @@ func (mi *ExtendedAgent) GetAoARanking() []int {
 /*
 * Decide whether to allow an agent into the team. This will be part of the group
 * strategy, and should be implemented by individual groups. During testing this
-* function is mocked. 
-*/
+* function is mocked.
+ */
 func (mi *ExtendedAgent) VoteOnAgentEntry(candidateID uuid.UUID) bool {
-    // TODO: Implement strategy for accepting an agent into the team. 
-    // Return true to accept them, false to not accept them. 
-    return true
+	// TODO: Implement strategy for accepting an agent into the team.
+	// Return true to accept them, false to not accept them.
+	return true
 }

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -12,7 +12,7 @@ type IExtendedAgent interface {
 	GetTeamID() uuid.UUID
 	GetLastTeamID() uuid.UUID
 	GetTrueScore() int
-    GetTeamRanking() []uuid.UUID
+	GetTeamRanking() []uuid.UUID
 
 	// Functions that involve strategic decisions
 	StartTeamForming(instance IExtendedAgent, agentInfoList []ExposedAgentInfo)
@@ -27,6 +27,7 @@ type IExtendedAgent interface {
 	SetTrueScore(score int)
 	SetAgentContributionAuditResult(agentID uuid.UUID, result bool)
 	SetAgentWithdrawalAuditResult(agentID uuid.UUID, result bool)
+	SetTeamRanking(teamRanking []uuid.UUID)
 	DecideStick()
 	DecideRollAgain()
 

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -12,6 +12,7 @@ type IExtendedAgent interface {
 	GetTeamID() uuid.UUID
 	GetLastTeamID() uuid.UUID
 	GetTrueScore() int
+    GetTeamRanking() []uuid.UUID
 
 	// Functions that involve strategic decisions
 	StartTeamForming(instance IExtendedAgent, agentInfoList []ExposedAgentInfo)

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -36,6 +36,7 @@ type IExtendedAgent interface {
 	StickOrAgain() bool
 	DecideContribution() int
 	DecideWithdrawal() int
+    VoteOnAgentEntry(candidateID uuid.UUID) bool
 
 	// Messaging functions
 	HandleTeamFormationMessage(msg *TeamFormationMessage)

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -36,7 +36,7 @@ type IExtendedAgent interface {
 	StickOrAgain() bool
 	DecideContribution() int
 	DecideWithdrawal() int
-    VoteOnAgentEntry(candidateID uuid.UUID) bool
+	VoteOnAgentEntry(candidateID uuid.UUID) bool
 
 	// Messaging functions
 	HandleTeamFormationMessage(msg *TeamFormationMessage)

--- a/common/IServer.go
+++ b/common/IServer.go
@@ -20,5 +20,5 @@ type IServer interface {
 
 	// Debug functions
 	LogAgentStatus()
-    PrintOrphanPool()
+	PrintOrphanPool()
 }

--- a/common/IServer.go
+++ b/common/IServer.go
@@ -17,6 +17,7 @@ type IServer interface {
 	StartAgentTeamForming()
 
 	GetTeam(agentID uuid.UUID) *Team
+	GetTeamFromTeamID(teamID uuid.UUID) *Team
 
 	// Debug functions
 	LogAgentStatus()

--- a/common/IServer.go
+++ b/common/IServer.go
@@ -20,4 +20,5 @@ type IServer interface {
 
 	// Debug functions
 	LogAgentStatus()
+    PrintOrphanPool()
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 )
 
 require (
+	bou.ke/monkey v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,10 @@ require (
 	github.com/MattSScott/basePlatformSOMAS/v2 v2.1.0
 	github.com/google/uuid v1.3.0
 )
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,13 @@
 github.com/MattSScott/basePlatformSOMAS/v2 v2.1.0 h1:VajDTjo0rqcZbTcuq5zICNqG6nQsvC0PszDEnaZ0Omg=
 github.com/MattSScott/basePlatformSOMAS/v2 v2.1.0/go.mod h1:U3HB8aYWfq+1xo1eHQhZz6yzY4kCTssrf2oDI0VvOY4=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 github.com/MattSScott/basePlatformSOMAS/v2 v2.1.0 h1:VajDTjo0rqcZbTcuq5zICNqG6nQsvC0PszDEnaZ0Omg=
 github.com/MattSScott/basePlatformSOMAS/v2 v2.1.0/go.mod h1:U3HB8aYWfq+1xo1eHQhZz6yzY4kCTssrf2oDI0VvOY4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -453,7 +453,7 @@ func (cs *EnvironmentServer) GetTeam(agentID uuid.UUID) *common.Team {
 	return cs.teams[cs.GetAgentMap()[agentID].GetTeamID()]
 }
 
-// Get team from team ID, mostly for testing. 
+// Get team from team ID, mostly for testing.
 func (cs *EnvironmentServer) GetTeamFromTeamID(teamID uuid.UUID) *common.Team {
-    return cs.teams[teamID]
+	return cs.teams[teamID]
 }

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -23,7 +23,7 @@ type EnvironmentServer struct {
 
 	roundScoreThreshold int
 	deadAgents          []common.IExtendedAgent
-    orphanPool OrphanPoolType
+	orphanPool          OrphanPoolType
 
 	// set of options for team strategies (agents rank these options)
 	aoaMenu []aoa.IArticlesOfAssociation
@@ -250,25 +250,24 @@ func (cs *EnvironmentServer) LogAgentStatus() {
 	}
 }
 
-/* 
+/*
 * Print the contents of the orphan pool. Careful as this will not necessarily
-* print the elements in the order that you added them. 
-*/
+* print the elements in the order that you added them.
+ */
 func (cs *EnvironmentServer) PrintOrphanPool() {
-    for i, v := range cs.orphanPool {
-        // truncate the UUIDs to make it easier to read
-        shortAgentId := i.String()[:8]
-        shortTeamIds := make([]string, len(v))
+	for i, v := range cs.orphanPool {
+		// truncate the UUIDs to make it easier to read
+		shortAgentId := i.String()[:8]
+		shortTeamIds := make([]string, len(v))
 
-        // go over all the teams in the wishlist and add to shortened IDs
-        for _, teamID := range v {
-            shortTeamIds = append(shortTeamIds, teamID.String()[:8])
-        }
+		// go over all the teams in the wishlist and add to shortened IDs
+		for _, teamID := range v {
+			shortTeamIds = append(shortTeamIds, teamID.String()[:8])
+		}
 
-        fmt.Println(shortAgentId, " Wants to join : ", shortTeamIds)
-    }
+		fmt.Println(shortAgentId, " Wants to join : ", shortTeamIds)
+	}
 }
-
 
 // pretty logging to show all team status
 func (cs *EnvironmentServer) LogTeamStatus() {

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -28,6 +28,13 @@ type EnvironmentServer struct {
 func (cs *EnvironmentServer) RunTurn(i, j int) {
 	fmt.Printf("\n\nIteration %v, Turn %v, current agent count: %v\n", i, j, len(cs.GetAgentMap()))
 
+    // Go over the list of all agents and add orphans to the orphan pool if
+    // they are not already there
+    cs.PickUpOrphans()
+
+    // Attempt to allocate the orphans to their preferred teams
+    cs.AllocateOrphans()
+
 	cs.teamsMutex.Lock()
 	defer cs.teamsMutex.Unlock()
 

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -28,12 +28,12 @@ type EnvironmentServer struct {
 func (cs *EnvironmentServer) RunTurn(i, j int) {
 	fmt.Printf("\n\nIteration %v, Turn %v, current agent count: %v\n", i, j, len(cs.GetAgentMap()))
 
-    // Go over the list of all agents and add orphans to the orphan pool if
-    // they are not already there
-    cs.PickUpOrphans()
+	// Go over the list of all agents and add orphans to the orphan pool if
+	// they are not already there
+	cs.PickUpOrphans()
 
-    // Attempt to allocate the orphans to their preferred teams
-    cs.AllocateOrphans()
+	// Attempt to allocate the orphans to their preferred teams
+	cs.AllocateOrphans()
 
 	cs.teamsMutex.Lock()
 	defer cs.teamsMutex.Unlock()

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -450,7 +450,7 @@ func (cs *EnvironmentServer) GetTeam(agentID uuid.UUID) *common.Team {
 
 // Get team from team ID, mostly for testing.
 func (cs *EnvironmentServer) GetTeamFromTeamID(teamID uuid.UUID) *common.Team {
-	return cs.teams[teamID]
+	return cs.Teams[teamID]
 }
 
 // Possibly needs to look at what team/AoA is being used to tally up the votes

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -452,3 +452,8 @@ func (cs *EnvironmentServer) GetTeam(agentID uuid.UUID) *common.Team {
 	// defer cs.teamsMutex.RUnlock()
 	return cs.teams[cs.GetAgentMap()[agentID].GetTeamID()]
 }
+
+// Get team from team ID, mostly for testing. 
+func (cs *EnvironmentServer) GetTeamFromTeamID(teamID uuid.UUID) *common.Team {
+    return cs.teams[teamID]
+}

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -23,6 +23,7 @@ type EnvironmentServer struct {
 
 	roundScoreThreshold int
 	deadAgents          []common.IExtendedAgent
+    orphanPool OrphanPoolType
 
 	// set of options for team strategies (agents rank these options)
 	aoaMenu []aoa.IArticlesOfAssociation
@@ -248,6 +249,26 @@ func (cs *EnvironmentServer) LogAgentStatus() {
 		fmt.Printf("Agent %v is dead\n", agent.GetID())
 	}
 }
+
+/* 
+* Print the contents of the orphan pool. Careful as this will not necessarily
+* print the elements in the order that you added them. 
+*/
+func (cs *EnvironmentServer) PrintOrphanPool() {
+    for i, v := range cs.orphanPool {
+        // truncate the UUIDs to make it easier to read
+        shortAgentId := i.String()[:8]
+        shortTeamIds := make([]string, len(v))
+
+        // go over all the teams in the wishlist and add to shortened IDs
+        for _, teamID := range v {
+            shortTeamIds = append(shortTeamIds, teamID.String()[:8])
+        }
+
+        fmt.Println(shortAgentId, " Wants to join : ", shortTeamIds)
+    }
+}
+
 
 // pretty logging to show all team status
 func (cs *EnvironmentServer) LogTeamStatus() {

--- a/server/OrphanPool.go
+++ b/server/OrphanPool.go
@@ -23,7 +23,7 @@ const MajorityVoteThreshold float32 = 0.7
 *
 * There is no logic in this function to check for the case where the agent is
 * already in the team, this is not the responsibility of this function. It
-* should not happen if the orphan pool is correctly managed.  
+* should not happen if the orphan pool is correctly managed.
  */
 func (cs *EnvironmentServer) RequestOrphanEntry(orphanID, teamID uuid.UUID, entryThreshold float32) bool {
 	// Get the team and the current number of team members
@@ -36,7 +36,7 @@ func (cs *EnvironmentServer) RequestOrphanEntry(orphanID, teamID uuid.UUID, entr
 	// For each agent in the team
 	for _, agentID := range team.Agents {
 		// Get their vote
-		vote := agent_map[agentID].VoteOnAgentEntry(agentID)
+		vote := agent_map[agentID].VoteOnAgentEntry(orphanID)
 		// increment the total votes if they vote 'yes'
 		if vote {
 			total_votes++

--- a/server/OrphanPool.go
+++ b/server/OrphanPool.go
@@ -23,7 +23,7 @@ const MajorityVoteThreshold float32 = 0.7
  */
 func (cs *EnvironmentServer) RequestOrphanEntry(orphanID, teamID uuid.UUID, entryThreshold float32) bool {
 	// Get the team and the current number of team members
-	team := cs.GetTeam(teamID)
+	team := cs.GetTeamFromTeamID(teamID)
 	agent_map := cs.GetAgentMap()
 
 	num_members := len(team.Agents)

--- a/server/OrphanPool.go
+++ b/server/OrphanPool.go
@@ -84,3 +84,27 @@ func (cs *EnvironmentServer) AllocateOrphans() {
 	// Assign the unallocated pool as the new orphan pool.
 	cs.orphanPool = unallocated
 }
+
+/*
+* Go over all the agents in the agent map. If there is an agent that is not
+* part of a team, then add it to the orphan pool. This allows the server to
+* actively pick up agents that have been removed from a team or that have left.
+* This prevents agents from having to tell the server to 'make me an orphan'. 
+*
+* This will not break for dead agents, because dead agents should be in a
+* separate map. (deadAgents)
+*/
+func (cs *EnvironmentServer) PickUpOrphans() {
+    // sweep over all the agents in the server's agent map
+    for agentID := range cs.GetAgentMap() {
+        // if the agent does not belong to a team, and is not in the orphan
+        // pool already, then add it to the orphan pool. 
+        _, exists := cs.orphanPool[agentID]
+
+        if !exists {
+		    fmt.Printf("%v was added to the orphan pool \n", agentID)
+            cs.orphanPool[agentID] = make([]uuid.UUID, 0) 
+        }
+    }
+}
+

--- a/server/OrphanPool.go
+++ b/server/OrphanPool.go
@@ -20,6 +20,10 @@ const MajorityVoteThreshold float32 = 0.7
 * into the team. This function accepts a threshold, that is used to determine
 * whether to grant entry or not. For example, a threshold of 0.7 means that at
 * least 70% of agents in the team have to be willing to accept the orphan.
+*
+* There is no logic in this function to check for the case where the agent is
+* already in the team, this is not the responsibility of this function. It
+* should not happen if the orphan pool is correctly managed.  
  */
 func (cs *EnvironmentServer) RequestOrphanEntry(orphanID, teamID uuid.UUID, entryThreshold float32) bool {
 	// Get the team and the current number of team members

--- a/server/OrphanPool.go
+++ b/server/OrphanPool.go
@@ -1,0 +1,116 @@
+package environmentServer
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+)
+
+/* Declare the orphan pool for keeping track of agents that are not currently
+* part of a team. This maps agentID -> slice of teamIDs that agent wants to
+* join. Note that the slice of teams is processed in order, so the agent should
+* put the team it most wants to join at the start of the slice. */
+type orphanPool map[uuid.UUID][]uuid.UUID
+var pool = make(orphanPool)
+
+// The percentage of agents that have to vote 'accept' in order for an orphan
+// to be taken into a team
+const MajorityVoteThreshold float32 = 0.7 
+
+/* 
+* Print the contents of the pool. Careful as this will not necessarily print
+* the elements in the order that you added them. 
+*/
+func (pool orphanPool) Print() {
+    for i, v := range pool {
+        // truncate the UUIDs to make it easier to read
+        shortAgentId := i.String()[:8]
+        shortTeamIds := make([]string, len(v))
+
+        // go over all the teams in the wishlist and add to shortened IDs
+        for _, teamID := range v {
+            shortTeamIds = append(shortTeamIds, teamID.String()[:8])
+        }
+
+        fmt.Println(shortAgentId, " Wants to join : ", shortTeamIds)
+    }
+}
+
+/* 
+* Ask all the agents in a team if they would be willing to accept an orphan into the team
+*/
+func (cs *EnvironmentServer) RequestOrphanEntry(orphanID, teamID uuid.UUID, entryThreshold) bool {
+    // todo
+    // todo
+}
+
+/*
+* Return a function (closure) for counting up the total votes in a team. 
+*/
+func voteAdder() func(bool) int {
+    // An instance of this 'votes' var will be created for each closure
+    // created. Whenever that closure is called, it will increment its own copy
+    // of votes! No need to keep data in another data structure. 
+    votes := 0
+    return func(agent_vote bool) int {
+        // increment the total number of votes only if the agent returned
+        // true, i.e. 'yes I will accept this member into the team'
+        if agent_vote { votes += 1 }
+        return votes
+    }
+}
+
+/*
+* Go through the pool and attempt to allocate each of the orphans to a team,
+* based on the preference they have expressed.
+*/
+func (bds * BaseDiceServer) AllocateOrphans() {
+    // for each orphan currently in the pool / shelter
+    for orphan, teamsList := range pool {
+        // for each team that orphan wants to join
+        for _, teamID := range teamsList {
+            // get the members of that team, if the team exists
+            team, ok := bds.teams[teamID]
+            if !ok { 
+                // if the orphan is trying to join a team that does not exist,
+                // make a not of this but do not kill the program. 
+                fmt.Print("Orphan ", orphan, " tried to join team ", teamID, " which does not exist")
+                continue 
+            }
+            // otherwise, add the vote of each member
+            adder := voteAdder()
+            members := team.GetTeamMembers()
+            var votes int
+            for _, agent := range members {
+                votes = adder(GetAgentVoteFromId(orphan, agent))
+            }
+
+            // calculate the percentage of agents that voted yes
+            acceptancePercentage := float32(votes) / float32(len(members))
+            
+            // add agent to team only if acceptance is above percentage
+            if acceptancePercentage >= MajorityVoteThreshold {
+                // add the orphan to the team
+                team.AddMember(orphan) 
+                // tell the orphan what team it now belongs to
+                bds.GetAgentMap()[orphan].SetTeam(team) 
+                // move onto the next orphan in the pool
+                delete(pool, orphan)
+                break
+            }
+        }
+    }
+}
+
+// test code ---------------------------------------
+
+func RunTests() {
+
+    pool = orphanPool{
+        uuid.New(): {uuid.New(), uuid.New(), uuid.New()},
+        uuid.New(): {uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()},
+        uuid.New(): {}, // outcast, does not want to join any team. 
+        uuid.New(): {uuid.New()}, 
+    }
+
+    pool.Print()
+}

--- a/server/OrphanPool.go
+++ b/server/OrphanPool.go
@@ -9,8 +9,8 @@ import (
 * part of a team. This maps agentID -> slice of teamIDs that agent wants to
 * join. Note that the slice of teams is processed in order, so the agent should
 * put the team it most wants to join at the start of the slice. */
-type orphanPool map[uuid.UUID][]uuid.UUID
-var pool = make(orphanPool)
+type OrphanPoolType map[uuid.UUID][]uuid.UUID
+var pool = make(OrphanPoolType)
 
 // The percentage of agents that have to vote 'accept' in order for an orphan
 // to be taken into a team
@@ -20,7 +20,7 @@ const MajorityVoteThreshold float32 = 0.7
 * Print the contents of the pool. Careful as this will not necessarily print
 * the elements in the order that you added them. 
 */
-func (pool orphanPool) Print() {
+func (pool OrphanPoolType) Print() {
     for i, v := range pool {
         // truncate the UUIDs to make it easier to read
         shortAgentId := i.String()[:8]
@@ -75,7 +75,7 @@ func (cs *EnvironmentServer) AllocateOrphans() {
     // This is because we want to only keep the unallocated orphans in the
     // pool. This is the safer alternative to deleting from the pool as we are
     // iterating through it. 
-    unallocated := make(orphanPool) 
+    unallocated := make(OrphanPoolType) 
 
     // for each orphan currently in the pool / shelter
     for orphanID, teamsList := range pool {

--- a/server/OrphanPool.go
+++ b/server/OrphanPool.go
@@ -10,92 +10,73 @@ import (
 * join. Note that the slice of teams is processed in order, so the agent should
 * put the team it most wants to join at the start of the slice. */
 type OrphanPoolType map[uuid.UUID][]uuid.UUID
-var pool = make(OrphanPoolType)
 
 // The percentage of agents that have to vote 'accept' in order for an orphan
 // to be taken into a team
-const MajorityVoteThreshold float32 = 0.7 
+const MajorityVoteThreshold float32 = 0.7
 
-/* 
-* Print the contents of the pool. Careful as this will not necessarily print
-* the elements in the order that you added them. 
-*/
-func (pool OrphanPoolType) Print() {
-    for i, v := range pool {
-        // truncate the UUIDs to make it easier to read
-        shortAgentId := i.String()[:8]
-        shortTeamIds := make([]string, len(v))
-
-        // go over all the teams in the wishlist and add to shortened IDs
-        for _, teamID := range v {
-            shortTeamIds = append(shortTeamIds, teamID.String()[:8])
-        }
-
-        fmt.Println(shortAgentId, " Wants to join : ", shortTeamIds)
-    }
-}
-
-/* 
+/*
 * Ask all the agents in a team if they would be willing to accept an orphan
 * into the team. This function accepts a threshold, that is used to determine
 * whether to grant entry or not. For example, a threshold of 0.7 means that at
-* least 70% of agents in the team have to be willing to accept the orphan. 
-*/
+* least 70% of agents in the team have to be willing to accept the orphan.
+ */
 func (cs *EnvironmentServer) RequestOrphanEntry(orphanID, teamID uuid.UUID, entryThreshold float32) bool {
-    // Get the team and the current number of team members
-    team := cs.GetTeam(teamID)
-    agent_map := cs.GetAgentMap()
+	// Get the team and the current number of team members
+	team := cs.GetTeam(teamID)
+	agent_map := cs.GetAgentMap()
 
-    num_members := len(team.Agents) 
-    total_votes := 0
+	num_members := len(team.Agents)
+	total_votes := 0
 
-    // For each agent in the team
-    for _, agentID := range team.Agents {
-        // Get their vote
-        vote := agent_map[agentID].VoteOnAgentEntry(agentID)
-        // increment the total votes if they vote 'yes'
-        if vote { total_votes++ }
-    }
+	// For each agent in the team
+	for _, agentID := range team.Agents {
+		// Get their vote
+		vote := agent_map[agentID].VoteOnAgentEntry(agentID)
+		// increment the total votes if they vote 'yes'
+		if vote {
+			total_votes++
+		}
+	}
 
-    // Calculate the acceptance ratio and return 'yes' only if enough of the
-    // team has voted to accept. 
-    acceptance := float32(total_votes) / float32(num_members)
-    return (acceptance >= entryThreshold)
+	// Calculate the acceptance ratio and return 'yes' only if enough of the
+	// team has voted to accept.
+	acceptance := float32(total_votes) / float32(num_members)
+	return (acceptance >= entryThreshold)
 }
-
 
 /*
 * Go through the pool and attempt to allocate each of the orphans to a team,
 * based on the preference they have expressed.
-*/
+ */
 func (cs *EnvironmentServer) AllocateOrphans() {
-    agent_map := cs.GetAgentMap()
+	agent_map := cs.GetAgentMap()
 
-    // Create pool for keeping track of which orphans have not been allocated.
-    // This is because we want to only keep the unallocated orphans in the
-    // pool. This is the safer alternative to deleting from the pool as we are
-    // iterating through it. 
-    unallocated := make(OrphanPoolType) 
+	// Create pool for keeping track of which orphans have not been allocated.
+	// This is because we want to only keep the unallocated orphans in the
+	// pool. This is the safer alternative to deleting from the pool as we are
+	// iterating through it.
+	unallocated := make(OrphanPoolType)
 
-    // for each orphan currently in the pool / shelter
-    for orphanID, teamsList := range pool {
-        // for each team that orphan wants to join
-        for _, teamID := range teamsList {
-            accepted := cs.RequestOrphanEntry(orphanID, teamID, MajorityVoteThreshold) 
-            // If the team has voted to accept the orphan
-            if accepted {
-                orphan := agent_map[orphanID]
-                orphan.SetTeamID(teamID) // Update agent's knowledge of its team
-                cs.AddAgentToTeam(orphanID, teamID) // Update team's knowledge of its agents
-                delete(pool, orphanID) // remove the agent from the orphan pool
-            }
-            // Otherwise, continue to the next team in the preference list. 
-        }
+	// for each orphan currently in the pool / shelter
+	for orphanID, teamsList := range cs.orphanPool {
+		// for each team that orphan wants to join
+		for _, teamID := range teamsList {
+			accepted := cs.RequestOrphanEntry(orphanID, teamID, MajorityVoteThreshold)
+			// If the team has voted to accept the orphan
+			if accepted {
+				orphan := agent_map[orphanID]
+				orphan.SetTeamID(teamID)            // Update agent's knowledge of its team
+				cs.AddAgentToTeam(orphanID, teamID) // Update team's knowledge of its agents
+				delete(cs.orphanPool, orphanID)     // remove the agent from the orphan pool
+			}
+			// Otherwise, continue to the next team in the preference list.
+		}
 
-        unallocated[orphanID] = teamsList // add to unallocated
-        fmt.Printf("%v remains in the orphan pool after allocation...\n", orphanID)
-    }
+		unallocated[orphanID] = teamsList // add to unallocated
+		fmt.Printf("%v remains in the orphan pool after allocation...\n", orphanID)
+	}
 
-    // Assign the unallocated pool as the new orphan pool.
-    pool = unallocated
+	// Assign the unallocated pool as the new orphan pool.
+	cs.orphanPool = unallocated
 }

--- a/test/orphan_test.go
+++ b/test/orphan_test.go
@@ -7,8 +7,8 @@ package main
 
 import (
 	"SOMAS_Extended/agents"
-	"github.com/google/uuid"
 	server "SOMAS_Extended/server"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert" // assert package, easier to
 	"testing"                            // built-in go testing package
 	"time"
@@ -27,20 +27,20 @@ func TestBaseAllocation(t *testing.T) {
 
 	// Create a dummy server using the config
 	serv := server.MakeEnvServer(2, 2, 3, 1000*time.Millisecond, 10, agentConfig)
-    // Extract the list of agent IDs
-    agentIDs := make([]uuid.UUID, 0)
-    for id := range serv.GetAgentMap() {
-        agentIDs = append(agentIDs, id) 
-    }
+	// Extract the list of agent IDs
+	agentIDs := make([]uuid.UUID, 0)
+	for id := range serv.GetAgentMap() {
+		agentIDs = append(agentIDs, id)
+	}
 
-    teamID := serv.CreateAndInitTeamWithAgents(agentIDs)
-    agents := serv.GetAgentsInTeam(teamID)
-    assert.Equal(t, agentIDs, agents)
+	teamID := serv.CreateAndInitTeamWithAgents(agentIDs)
+	agents := serv.GetAgentsInTeam(teamID)
+	assert.Equal(t, agentIDs, agents)
 
 	// Ask every team if it will accept every agent
-    for agentID, agent := range serv.GetAgentMap() {
-        teamID := agent.GetTeamID() 
-        accepted := serv.RequestOrphanEntry(agentID, teamID, 1.00)
-        assert.Equal(t, true, accepted)
-    }
+	for agentID, agent := range serv.GetAgentMap() {
+		teamID := agent.GetTeamID()
+		accepted := serv.RequestOrphanEntry(agentID, teamID, 1.00)
+		assert.Equal(t, true, accepted)
+	}
 }

--- a/test/orphan_test.go
+++ b/test/orphan_test.go
@@ -7,8 +7,8 @@ package main
 
 import (
 	"SOMAS_Extended/agents"
-	server "SOMAS_Extended/server"
 	"github.com/google/uuid"
+	server "SOMAS_Extended/server"
 	"github.com/stretchr/testify/assert" // assert package, easier to
 	"testing"                            // built-in go testing package
 	"time"
@@ -27,8 +27,20 @@ func TestBaseAllocation(t *testing.T) {
 
 	// Create a dummy server using the config
 	serv := server.MakeEnvServer(2, 2, 3, 1000*time.Millisecond, 10, agentConfig)
-	assert.NotNil(t, serv)
+    // Extract the list of agent IDs
+    agentIDs := make([]uuid.UUID, 0)
+    for id := range serv.GetAgentMap() {
+        agentIDs = append(agentIDs, id) 
+    }
 
-	// Ask all teams to accept any agent
+    teamID := serv.CreateAndInitTeamWithAgents(agentIDs)
+    agents := serv.GetAgentsInTeam(teamID)
+    assert.Equal(t, agentIDs, agents)
 
+	// Ask every team if it will accept every agent
+    for agentID, agent := range serv.GetAgentMap() {
+        teamID := agent.GetTeamID() 
+        accepted := serv.RequestOrphanEntry(agentID, teamID, 1.00)
+        assert.Equal(t, true, accepted)
+    }
 }

--- a/test/orphan_test.go
+++ b/test/orphan_test.go
@@ -3,7 +3,7 @@ package main
 /*
 * Code to test the functionality of the orphan pool, which deals with agents
 * that are not currently part of a team re-joining teams in subsequent turns.
- */
+*/
 
 import (
 	"SOMAS_Extended/agents"
@@ -15,19 +15,57 @@ import (
 )
 
 /*
-* Allocation as it occurs on the BasePlatform, where the VoteOnAgentEntry()
-* function returns true for every candidate ID
- */
-func TestBaseAllocation(t *testing.T) {
-	// Default Test Configuration
-	agentConfig := agents.AgentConfig{
+* Return a test server environment
+*/
+func CreateTestServer() *server.EnvironmentServer {
+    // Default test config
+    agentConfig := agents.AgentConfig{
 		InitScore:    0,
 		VerboseLevel: 10,
 	}
 
 	// Create a dummy server using the config
 	serv := server.MakeEnvServer(2, 2, 3, 1000*time.Millisecond, 10, agentConfig)
-	// Extract the list of agent IDs
+    return serv
+}
+
+/* As it stands it would be difficult to simulate different scenarios where
+* agents are accepted / rejected. To solve this problem we can introduce a mock
+* agent, which will allow us to override specific functions for testing
+* purposes. */
+type MockAgent struct { 
+    agents.ExtendedAgent 
+    /* We introduce the concept of a blacklist, such that the agent can
+    * deterministically accept / reject new agents from entering the team. This
+    * is done for testing purposes only. The VoteOnAgentEntry function will
+    * vote 'no' if the UUID is in the blacklist, and vote 'yes' otherwise. */
+    Blacklist []uuid.UUID
+}
+
+/* 
+* Override the VoteOnAgentEntry function to only accept if the agent is not in
+* the blacklist
+*/
+func (mi *MockAgent) VoteOnAgentEntry(candidateID uuid.UUID) bool {
+    // Iterate over all agents in blacklist and return false if UUID found
+    for _, blacklistedID := range mi.Blacklist {
+        if candidateID == blacklistedID {
+            return false
+        }
+    }
+    // return true otherwise
+    return true
+}
+
+/*
+* Allocation as it occurs on the BasePlatform, where the VoteOnAgentEntry()
+* function returns true for every candidate ID
+ */
+func TestBaseAllocation(t *testing.T) {
+	// Default Test Configuration
+    serv := CreateTestServer()
+
+    // Extract the list of agent IDs
 	agentIDs := make([]uuid.UUID, 0)
 	for id := range serv.GetAgentMap() {
 		agentIDs = append(agentIDs, id)
@@ -37,7 +75,9 @@ func TestBaseAllocation(t *testing.T) {
 	agents := serv.GetAgentsInTeam(teamID)
 	assert.Equal(t, agentIDs, agents)
 
-	// Ask every team if it will accept every agent
+    // Go through all agents, and ask the team it is already in if it will
+    // accept it. Yes this should technically never be asked, this is a base
+    // case. 
 	for agentID, agent := range serv.GetAgentMap() {
 		teamID := agent.GetTeamID()
 		accepted := serv.RequestOrphanEntry(agentID, teamID, 1.00)

--- a/test/orphan_test.go
+++ b/test/orphan_test.go
@@ -1,15 +1,34 @@
 package main
 
-/* 
+/*
 * Code to test the functionality of the orphan pool, which deals with agents
 * that are not currently part of a team re-joining teams in subsequent turns.
-*/
+ */
 
-import "testing"  // built-in go testing package
-import "github.com/stretchr/testify/assert"  // assert package, easier to 
+import (
+	"SOMAS_Extended/agents"
+	server "SOMAS_Extended/server"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert" // assert package, easier to
+	"testing"                            // built-in go testing package
+	"time"
+)
 
-func TestNoBreak(t *testing.T) {
-    result := 2 + 3
-    assert.Equal(t, 5, result)
+/*
+* Allocation as it occurs on the BasePlatform, where the VoteOnAgentEntry()
+* function returns true for every candidate ID
+ */
+func TestBaseAllocation(t *testing.T) {
+	// Default Test Configuration
+	agentConfig := agents.AgentConfig{
+		InitScore:    0,
+		VerboseLevel: 10,
+	}
+
+	// Create a dummy server using the config
+	serv := server.MakeEnvServer(2, 2, 3, 1000*time.Millisecond, 10, agentConfig)
+	assert.NotNil(t, serv)
+
+	// Ask all teams to accept any agent
+
 }
-

--- a/test/orphan_test.go
+++ b/test/orphan_test.go
@@ -1,0 +1,15 @@
+package main
+
+/* 
+* Code to test the functionality of the orphan pool, which deals with agents
+* that are not currently part of a team re-joining teams in subsequent turns.
+*/
+
+import "testing"  // built-in go testing package
+import "github.com/stretchr/testify/assert"  // assert package, easier to 
+
+func TestNoBreak(t *testing.T) {
+    result := 2 + 3
+    assert.Equal(t, 5, result)
+}
+


### PR DESCRIPTION
## Add Orphan Pool and re-join at the start of each turn

### Process Outline
- At the start of each `RunTurn()`, we call two new functions:
- `PickUpOrphans()` - the server iterates over the agent map and identifies any agents with a `nil` TeamID. It updates the common pool with the preferences of that agent - (the agent is free to modify its preferences at any point, we expose a Getter to the server so that it can update its records.)
- `AllocateOrphans()` - the server goes through each orphan's preferences and, for each team, calls a vote whether that agent should be accepted or not. If the vote is above a certain threshold (currently 70%, should this be defined in the AoA?), then the agent is accepted.  

In order to trigger re-allocation then, all an agent needs to do is set it's TeamID to `nil` and update it's preferences. The server will automatically pick it up at the start of the next `RunTurn()` call. 

### Tests: 
- `TestAlwaysAccept` - Agents always accept the orphans
- `TestAlwaysReject` - Agents always reject the orphans
- `TestAcceptIfInCurrentTeam` - An example strategy where an agent votes 'yes' to accept an orphan that is already in its team. This won't actually happen, it's just an example of some simple logic. 
- `TestAllocateOrphans` - Creates a team with 2 members, and leaves 2 orphans unallocated. Assigns the preferences of the orphans, and the server allocates them by calling a vote. 