### PR TITLE
Kill agent was causing the Segmentation Error Fault

### DIFF
--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -450,3 +450,22 @@ func (mi *ExtendedAgent) SetAoARanking(Preferences []int) {
 func (mi *ExtendedAgent) GetAoARanking() []int {
 	return mi.AoARanking
 }
+
+func (mi *ExtendedAgent) DecideLeaveTeam() bool {
+	// Generate a random number between 0 and 9
+	decision := rand.Intn(10)
+
+	// If the random number is 0, the agent decides to leave (10% chance)
+	if decision == 0 {
+		if mi.verboseLevel > 6 {
+			fmt.Printf("Agent %s decided to leave the team (10%% probability triggered)\n", mi.GetID())
+		}
+		return true
+	}
+
+	// Otherwise, the agent stays in the team
+	if mi.verboseLevel > 6 {
+		fmt.Printf("Agent %s decided to stay in the team\n", mi.GetID())
+	}
+	return false
+}

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -35,6 +35,7 @@ type IExtendedAgent interface {
 	StickOrAgain() bool
 	DecideContribution() int
 	DecideWithdrawal() int
+	DecideLeaveTeam() bool
 
 	// Messaging functions
 	HandleTeamFormationMessage(msg *TeamFormationMessage)


### PR DESCRIPTION
Related to issue #52 

This PR resolves an issue where the KillAgent function causes a panic when attempting to remove an agent that is not part of any team (teamID == uuid.Nil).

Changes Made:
Updated KillAgent to handle agents without a team by:
Always removing the agent from the agent map.
Adding the agent to the deadAgents list.
Ensuring proper checks for nil and non-existent agents.