### PR TITLE
Fixing module paths to use GitHub URL

### DIFF
--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/uuid"
 
-	common "SOMAS_Extended/common"
+	common "github.com/ADimoska/SOMASExtended/common"
 
 	// TODO:
 

--- a/agents/MI_256_v1.go
+++ b/agents/MI_256_v1.go
@@ -1,8 +1,8 @@
 package agents
 
 import (
-	"SOMAS_Extended/common"
 	"fmt"
+	common "github.com/ADimoska/SOMASExtended/common"
 	"math/rand"
 
 	"github.com/MattSScott/basePlatformSOMAS/v2/pkg/agent"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module SOMAS_Extended
+module github.com/ADimoska/SOMASExtended
 
 go 1.23.2
 

--- a/main.go
+++ b/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"SOMAS_Extended/agents"
-	envServer "SOMAS_Extended/server"
+	agents "github.com/ADimoska/SOMASExtended/agents"
+	envServer "github.com/ADimoska/SOMASExtended/server"
 )
 
 func main() {

--- a/messages/ExtendedMessage.go
+++ b/messages/ExtendedMessage.go
@@ -1,7 +1,7 @@
 package messages
 
 import (
-	"SOMAS_Extended/common"
+	"github.com/ADimoska/SOMASExtended/common"
 
 	"github.com/MattSScott/basePlatformSOMAS/v2/pkg/message"
 	"github.com/google/uuid"

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -1,9 +1,9 @@
 package environmentServer
 
 import (
-	"SOMAS_Extended/agents"
-	common "SOMAS_Extended/common"
 	"fmt"
+	agents "github.com/ADimoska/SOMASExtended/agents"
+	common "github.com/ADimoska/SOMASExtended/common"
 	"math/rand"
 	"sync"
 	"time"


### PR DESCRIPTION
- Fixing this projects module file, and other module imports to use full GitHub URL

_Laying the groundwork for the ability to import SOMASExtended from other go modules, e.g. the separate module/repos for each Team's specific agent implementations_