### PR TITLE
Adding permissions to write tags

### DIFF
--- a/.github/workflows/run-auto-tag-increment.yml
+++ b/.github/workflows/run-auto-tag-increment.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   autotag:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Please review, this might fix why GitHub Action is failing with `Error: Resource not accessible by integration`