### PR TITLE
Add 'v' prefix to git tags

### DIFF
--- a/.github/workflows/run-auto-tag-increment.yml
+++ b/.github/workflows/run-auto-tag-increment.yml
@@ -17,3 +17,4 @@ jobs:
         uses: phish108/autotag-action@v1.1.64
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          with-v: true


### PR DESCRIPTION
adds `v` prefix to version tag
e.g. `v1.0.6` instead of `1.0.6` 