### PR TITLE
Re-work auditing to be based on a centralized system

### DIFF
--- a/common/Audit.go
+++ b/common/Audit.go
@@ -1,0 +1,75 @@
+package common
+
+import "github.com/google/uuid"
+
+type AuditRecord struct {
+	auditMap map[uuid.UUID][]int
+	duration int
+	cost     int
+	// reliability float64
+}
+
+// Getters
+func (a *AuditRecord) GetAuditMap() map[uuid.UUID][]int {
+	return a.auditMap
+}
+
+func (a *AuditRecord) GetAuditDuration() int {
+	return a.duration
+}
+
+func (a *AuditRecord) GetAuditCost() int {
+	return a.cost
+}
+
+// Get the number of infractions in the last n rounds, given by the quality of the audit
+func (a *AuditRecord) GetAgentHistory(agentId uuid.UUID) int {
+	infractions := 0
+	records := a.auditMap[agentId]
+
+	history := len(records)
+	if history > a.duration {
+		history = a.duration
+	}
+
+	for _, infraction := range records[len(records)-history:] {
+		infractions += infraction
+	}
+
+	return infractions
+}
+
+// After a successful audit, clear the history of the agent so that there are
+// no repeated warnings for the same infraction (this may change if using probabilistic auditing as well)
+func (a *AuditRecord) ClearAgentHistory(agentId uuid.UUID) {
+	a.auditMap[agentId] = []int{}
+}
+
+// After an agent's contribution, add a new record to the audit map
+func (a *AuditRecord) AddAgentRecord(agentId uuid.UUID, roundInfractions int) {
+	if _, ok := a.auditMap[agentId]; !ok {
+		a.auditMap[agentId] = []int{}
+	}
+
+	a.auditMap[agentId] = append(a.auditMap[agentId], roundInfractions)
+}
+
+// After the agent's withdrawal, which is after the contribution, update the last record instead of adding a new one
+func (a *AuditRecord) UpdateLastRecord(agentId uuid.UUID, extraInfractions int) {
+	if _, ok := a.auditMap[agentId]; !ok {
+		a.auditMap[agentId] = []int{}
+	}
+
+	records := a.auditMap[agentId]
+	records[len(records)-1] += extraInfractions
+}
+
+func NewAuditRecord(duration int) *AuditRecord {
+	cost := duration // For now, this can change depending on the tiering system
+
+	return &AuditRecord{
+		auditMap: make(map[uuid.UUID][]int),
+		duration: duration,
+		cost:     cost,
+	}
+}

--- a/common/Audit.go
+++ b/common/Audit.go
@@ -47,10 +47,7 @@ func (a *AuditRecord) GetAllInfractions(agentId uuid.UUID) int {
 	infractions := 0
 	records := a.auditMap[agentId]
 
-	history := len(records)
-	if history > a.duration {
-		history = a.duration
-	}
+	history := min(a.duration, len(records))
 
 	for _, infraction := range records[len(records)-history:] {
 		infractions += infraction
@@ -94,5 +91,9 @@ func (a *AuditRecord) IncrementLastRecord(agentId uuid.UUID) {
 	}
 
 	records := a.auditMap[agentId]
+	if len(records) == 0 {
+		return
+	}
+
 	records[len(records)-1]++
 }

--- a/common/FixedAoA.go
+++ b/common/FixedAoA.go
@@ -7,22 +7,27 @@ import (
 )
 
 type FixedAoA struct {
-	ContributionAuditMap map[uuid.UUID]bool
-	WithdrawalAuditMap   map[uuid.UUID]bool
+	auditRecord *AuditRecord
 }
-
-func (f *FixedAoA) ResetAuditMap() {}
 
 func (f *FixedAoA) GetExpectedContribution(agentId uuid.UUID, agentScore int) int {
 	return agentScore
 }
 
 func (f *FixedAoA) SetContributionAuditResult(agentId uuid.UUID, agentScore int, agentActualContribution int, agentStatedContribution int) {
+	// If the agent's actual contribution is not equal to the stated contribution, then the agent is cheating
+	infraction := 0
+	if agentActualContribution != agentStatedContribution {
+		infraction = 1
+	}
+	f.auditRecord.AddRecord(agentId, infraction)
 }
 
 func (f *FixedAoA) GetContributionAuditResult(agentId uuid.UUID) bool {
 	// true means agent failed the audit (cheated)
-	return f.ContributionAuditMap[agentId]
+	infractions := f.auditRecord.GetAllInfractions(agentId) > 0
+	f.auditRecord.ClearAllInfractions(agentId)
+	return infractions
 }
 
 func (f *FixedAoA) GetExpectedWithdrawal(agentId uuid.UUID, agentScore int, commonPool int) int {
@@ -30,15 +35,21 @@ func (f *FixedAoA) GetExpectedWithdrawal(agentId uuid.UUID, agentScore int, comm
 }
 
 func (f *FixedAoA) SetWithdrawalAuditResult(agentId uuid.UUID, agentScore int, agentActualWithdrawal int, agentStatedWithdrawal int, commonPool int) {
+	// If the agent's actual withdrawal is not equal to the stated withdrawal, then the agent is cheating
+	if agentActualWithdrawal != agentStatedWithdrawal {
+		f.auditRecord.IncrementLastRecord(agentId)
+	}
 }
 
 func (f *FixedAoA) GetWithdrawalAuditResult(agentId uuid.UUID) bool {
 	// true means agent failed the audit (cheated)
-	return f.WithdrawalAuditMap[agentId]
+	infractions := f.auditRecord.GetAllInfractions(agentId) > 0
+	f.auditRecord.ClearAllInfractions(agentId)
+	return infractions
 }
 
 func (f *FixedAoA) GetAuditCost(commonPool int) int {
-	return 0
+	return f.auditRecord.GetAuditCost()
 }
 
 // MUST return UUID nil if audit should not be executed
@@ -64,6 +75,9 @@ func (t *FixedAoA) GetWithdrawalOrder(agentIDs []uuid.UUID) []uuid.UUID {
 	return shuffledAgents
 }
 
-func CreateFixedAoA() IArticlesOfAssociation {
-	return &FixedAoA{}
+func CreateFixedAoA(duration int) IArticlesOfAssociation {
+	auditRecord := NewAuditRecord(duration)
+	return &FixedAoA{
+		auditRecord: auditRecord,
+	}
 }

--- a/common/team.go
+++ b/common/team.go
@@ -24,7 +24,7 @@ func (team *Team) SetCommonPool(amount int) {
 
 // constructor: NewTeam creates a new Team with a unique TeamID and initializes other fields as blank.
 func NewTeam(teamID uuid.UUID) *Team {
-	teamAoA := CreateFixedAoA()
+	teamAoA := CreateFixedAoA(1)
 	return &Team{
 		TeamID:     teamID,        // Generate a unique TeamID
 		commonPool: 0,             // Initialize commonPool to 0

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -183,17 +183,17 @@ func (cs *EnvironmentServer) allocateAoAs() {
 		// Update the team's strategy
 		switch preference {
 		case 0:
-			team.TeamAoA = common.CreateFixedAoA()
+			team.TeamAoA = common.CreateFixedAoA(1)
 		case 1:
-			team.TeamAoA = common.CreateFixedAoA()
+			team.TeamAoA = common.CreateFixedAoA(1)
 		case 2:
-			team.TeamAoA = common.CreateFixedAoA()
+			team.TeamAoA = common.CreateFixedAoA(1)
 		case 3:
-			team.TeamAoA = common.CreateFixedAoA()
+			team.TeamAoA = common.CreateFixedAoA(1)
 		case 4:
-			team.TeamAoA = common.CreateFixedAoA()
+			team.TeamAoA = common.CreateFixedAoA(1)
 		default:
-			team.TeamAoA = common.CreateFixedAoA()
+			team.TeamAoA = common.CreateFixedAoA(1)
 		}
 
 		cs.Teams[team.TeamID] = team

--- a/test/audit_test.go
+++ b/test/audit_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"github.com/ADimoska/SOMASExtended/common"
+	"github.com/google/uuid"
+	"testing"
+)
+
+// Test if the audit duration gets dynamically updated, and all the records are kept up to date
+func TestAuditDuration(t *testing.T) {
+	ar := common.NewAuditRecord(3)
+	agentId := uuid.New()
+
+	// Add four records, only the three most recent should be considered
+	ar.AddRecord(agentId, 1)
+	ar.AddRecord(agentId, 0)
+	ar.AddRecord(agentId, 1)
+	ar.AddRecord(agentId, 1)
+
+	infractions := ar.GetAllInfractions(agentId)
+
+	if ar.GetAllInfractions(agentId) != 2 {
+		t.Errorf("expected %d infractions, got %d", 2, infractions)
+	}
+
+	// Increase duration before getting infractions
+	ar.SetAuditDuration(4)
+	infractions = ar.GetAllInfractions(agentId)
+
+	if infractions != 3 {
+		t.Errorf("expected %d infractions, got %d", 3, infractions)
+	}
+}
+
+// Test that once cleared, the past infractions are not double counted in future checks
+func TestClearAllInfractions(t *testing.T) {
+	ar := common.NewAuditRecord(5)
+	agentId := uuid.New()
+
+	ar.AddRecord(agentId, 1)
+	ar.AddRecord(agentId, 1)
+
+	ar.ClearAllInfractions(agentId)
+
+	ar.AddRecord(agentId, 0)
+
+	infractions := ar.GetAllInfractions(agentId)
+	if infractions != 0 {
+		t.Errorf("expected 0 infractions, got %d", infractions)
+	}
+}
+
+func TestIncrementLastRecord(t *testing.T) {
+	ar := common.NewAuditRecord(5)
+	agentId := uuid.New()
+
+	ar.AddRecord(agentId, 1)
+	ar.AddRecord(agentId, 0)
+
+	ar.IncrementLastRecord(agentId)
+
+	lastInfraction := ar.GetLastRecord(agentId)
+	if lastInfraction != 1 {
+		t.Errorf("expected 1, got %d", lastInfraction)
+	}
+
+	infractions := ar.GetAllInfractions(agentId)
+	if infractions != 2 {
+		t.Errorf("expected 2 infractions, got %d", infractions)
+	}
+}


### PR DESCRIPTION
This PR introduces an `AuditRecord` structure, which pre-computes the auditing results for all agents within a given team. It exposes this information with 100% reliability in a sliding window fashion (starting from the most recent record) to the server given a successful audit vote. The cost is currently set to be the same as the duration/length of the sliding window.

Considerations and Extensions:
- This re-work changes booleans to integers. This is because it is possible for there to be 2 instances of cheating within the same round. These can either be counted as one or two infractions. The option should lie with the individual teams' AoAs still.
- A hybrid probabilistic approach is being considered at this point, where the cost also leads to higher reliability of auditing. Perhaps a tiering system which serves as a multiplier to the base cost could be used.
- Dynamic window adjustment based on the average cost obtained from re-worked audit votes. This would involve changing the audit vote to include the duration of the requested records.