### PR TITLE
Fix allocateAoAs()

### DIFF
--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -54,7 +54,7 @@ func GetBaseAgents(funcs agent.IExposedServerFunctions[common.IExtendedAgent], c
 		Server:       funcs.(common.IServer), // Type assert the server functions to IServer interface
 		Score:        configParam.InitScore,
 		VerboseLevel: configParam.VerboseLevel,
-		AoARanking:   []int{3, 2, 1, 0},
+		AoARanking:   []int{0},
 		TeamRanking:  []uuid.UUID{},
 	}
 }

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"math/rand"
 	"sync"
+	"time"
 
 	gameRecorder "github.com/ADimoska/SOMASExtended/gameRecorder"
 	"github.com/google/uuid"

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -212,10 +212,6 @@ func (cs *EnvironmentServer) allocateAoAs() {
 
 		// Process votes from all team members
 		for _, agent := range team.Agents {
-			// Skip dead agents; they do not contribute to the voting process
-			if cs.IsAgentDead(agent) {
-				continue
-			}
 
 			// Get the agent's ranked preferences for AoAs (maximum of 6 ranked choices)
 			agentAoARanking := cs.GetAgentMap()[agent].GetAoARanking()

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -256,7 +256,7 @@ func (cs *EnvironmentServer) allocateAoAs() {
 			randomIndex := rand.Intn(len(tiedAoAs)) // Random choice among tied AoAs
 			selectedAoA = tiedAoAs[randomIndex]
 		} else {
-			selectedAoA = 0 // No valid votes; default AoA
+			selectedAoA = 1 + rand.Intn(6) // No valid votes, choose random AoA [1-6]
 		}
 
 		// Assign the selected AoA to the team's strategy based on its value


### PR DESCRIPTION
## Fix `allocateAoAs()`

#### Bug Fixes:
- fixed runtime error when submitting > 4 AoA preferences
- fixed Borda Count method

#### Features:
- randomly choose AoA in the event of a tie
  - Hence set base ExtendedAgent AoA preference to 0 (no preferences, happy with random)
  
#### Expected output
- if all agents have no AoA preference e.g. {0} then the AoA will be randomly assigned for each team, for each iteration of the game

 ```console
 -- Iteration 0 --
Team 9cedb286-4fcf-46d2-8523-8fc289404e8f has been assigned AoA 1
Team 40164d03-3381-4ea5-ae3a-ebe4c7fa31c3 has been assigned AoA 2
-- Iteration 1 --
Team f05fdf4a-96b0-49a5-936d-4ceb7f604710 has been assigned AoA 2
Team 9e1fb73c-6acf-449e-aebb-17f6b51580f5 has been assigned AoA 6
 ```