### PR TITLE
Agent Opinion Messaging

### DIFF
--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -338,6 +338,20 @@ func (mi *ExtendedAgent) HandleWithdrawalMessage(msg *common.WithdrawalMessage) 
 	// Team's agent should implement logic to store or process the reported withdrawal amount as desired
 }
 
+func (mi *ExtendedAgent) HandleOpinionRequestMessage(msg *common.OpinionRequestMessage) {
+	// Team's agent should implement logic to respond to opinion request as desired
+	log.Printf("Agent %s received opinion request from %s\n", mi.GetID(), msg.AgentID)
+	opinion := 70
+	opinionResponseMsg := mi.CreateOpinionResponseMessage(msg.AgentID, opinion)
+	log.Printf("Sending opinion response to %s\n", msg.AgentID)
+	mi.SendMessage(opinionResponseMsg, msg.AgentID) // Sent asynchronously, because this is "extra information"
+}
+
+func (mi *ExtendedAgent) HandleOpinionResponseMessage(msg *common.OpinionResponseMessage) {
+	// Team's agent should implement logic to store or process opinion response as desired
+	log.Printf("Agent %s received opinion response from %s: opinion=%d\n", mi.GetID(), msg.GetSender(), msg.Opinion)
+}
+
 func (mi *ExtendedAgent) BroadcastSyncMessageToTeam(msg message.IMessage[common.IExtendedAgent]) {
 	// Send message to all team members synchronously
 	agentsInTeam := mi.Server.GetAgentsInTeam(mi.TeamID)
@@ -388,6 +402,21 @@ func (mi *ExtendedAgent) CreateWithdrawalMessage(statedAmount int) *common.Withd
 	return &common.WithdrawalMessage{
 		BaseMessage:  mi.CreateBaseMessage(),
 		StatedAmount: statedAmount,
+	}
+}
+
+func (mi *ExtendedAgent) CreateOpinionRequestMessage(agentID uuid.UUID) *common.OpinionRequestMessage {
+	return &common.OpinionRequestMessage{
+		BaseMessage: mi.CreateBaseMessage(),
+		AgentID:     agentID,
+	}
+}
+
+func (mi *ExtendedAgent) CreateOpinionResponseMessage(agentID uuid.UUID, opinion int) *common.OpinionResponseMessage {
+	return &common.OpinionResponseMessage{
+		BaseMessage: mi.CreateBaseMessage(),
+		AgentID:     agentID,
+		Opinion:     opinion,
 	}
 }
 

--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -338,18 +338,18 @@ func (mi *ExtendedAgent) HandleWithdrawalMessage(msg *common.WithdrawalMessage) 
 	// Team's agent should implement logic to store or process the reported withdrawal amount as desired
 }
 
-func (mi *ExtendedAgent) HandleOpinionRequestMessage(msg *common.OpinionRequestMessage) {
+func (mi *ExtendedAgent) HandleAgentOpinionRequestMessage(msg *common.AgentOpinionRequestMessage) {
 	// Team's agent should implement logic to respond to opinion request as desired
 	log.Printf("Agent %s received opinion request from %s\n", mi.GetID(), msg.AgentID)
 	opinion := 70
-	opinionResponseMsg := mi.CreateOpinionResponseMessage(msg.AgentID, opinion)
+	opinionResponseMsg := mi.CreateAgentOpinionResponseMessage(msg.AgentID, opinion)
 	log.Printf("Sending opinion response to %s\n", msg.AgentID)
 	mi.SendMessage(opinionResponseMsg, msg.AgentID) // Sent asynchronously, because this is "extra information"
 }
 
-func (mi *ExtendedAgent) HandleOpinionResponseMessage(msg *common.OpinionResponseMessage) {
+func (mi *ExtendedAgent) HandleAgentOpinionResponseMessage(msg *common.AgentOpinionResponseMessage) {
 	// Team's agent should implement logic to store or process opinion response as desired
-	log.Printf("Agent %s received opinion response from %s: opinion=%d\n", mi.GetID(), msg.GetSender(), msg.Opinion)
+	log.Printf("Agent %s received opinion response from %s: opinion=%d\n", mi.GetID(), msg.GetSender(), msg.AgentOpinion)
 }
 
 func (mi *ExtendedAgent) BroadcastSyncMessageToTeam(msg message.IMessage[common.IExtendedAgent]) {
@@ -405,18 +405,18 @@ func (mi *ExtendedAgent) CreateWithdrawalMessage(statedAmount int) *common.Withd
 	}
 }
 
-func (mi *ExtendedAgent) CreateOpinionRequestMessage(agentID uuid.UUID) *common.OpinionRequestMessage {
-	return &common.OpinionRequestMessage{
+func (mi *ExtendedAgent) CreateAgentOpinionRequestMessage(agentID uuid.UUID) *common.AgentOpinionRequestMessage {
+	return &common.AgentOpinionRequestMessage{
 		BaseMessage: mi.CreateBaseMessage(),
 		AgentID:     agentID,
 	}
 }
 
-func (mi *ExtendedAgent) CreateOpinionResponseMessage(agentID uuid.UUID, opinion int) *common.OpinionResponseMessage {
-	return &common.OpinionResponseMessage{
-		BaseMessage: mi.CreateBaseMessage(),
-		AgentID:     agentID,
-		Opinion:     opinion,
+func (mi *ExtendedAgent) CreateAgentOpinionResponseMessage(agentID uuid.UUID, opinion int) *common.AgentOpinionResponseMessage {
+	return &common.AgentOpinionResponseMessage{
+		BaseMessage:  mi.CreateBaseMessage(),
+		AgentID:      agentID,
+		AgentOpinion: opinion,
 	}
 }
 

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -50,8 +50,8 @@ type IExtendedAgent interface {
 	HandleWithdrawalMessage(msg *WithdrawalMessage)
 	BroadcastSyncMessageToTeam(msg message.IMessage[IExtendedAgent])
 	HandleContributionMessage(msg *ContributionMessage)
-	HandleOpinionRequestMessage(msg *OpinionRequestMessage)
-	HandleOpinionResponseMessage(msg *OpinionResponseMessage)
+	HandleAgentOpinionRequestMessage(msg *AgentOpinionRequestMessage)
+	HandleAgentOpinionResponseMessage(msg *AgentOpinionResponseMessage)
 	StateContributionToTeam()
 	StateWithdrawalToTeam()
 
@@ -60,8 +60,8 @@ type IExtendedAgent interface {
 	CreateScoreReportMessage() *ScoreReportMessage
 	CreateContributionMessage(statedAmount int) *ContributionMessage
 	CreateWithdrawalMessage(statedAmount int) *WithdrawalMessage
-	CreateOpinionRequestMessage(agentID uuid.UUID) *OpinionRequestMessage
-	CreateOpinionResponseMessage(agentID uuid.UUID, opinion int) *OpinionResponseMessage
+	CreateAgentOpinionRequestMessage(agentID uuid.UUID) *AgentOpinionRequestMessage
+	CreateAgentOpinionResponseMessage(agentID uuid.UUID, opinion int) *AgentOpinionResponseMessage
 	LogSelfInfo()
 	GetAoARanking() []int
 	SetAoARanking(Preferences []int)

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -50,6 +50,8 @@ type IExtendedAgent interface {
 	HandleWithdrawalMessage(msg *WithdrawalMessage)
 	BroadcastSyncMessageToTeam(msg message.IMessage[IExtendedAgent])
 	HandleContributionMessage(msg *ContributionMessage)
+	HandleOpinionRequestMessage(msg *OpinionRequestMessage)
+	HandleOpinionResponseMessage(msg *OpinionResponseMessage)
 	StateContributionToTeam()
 	StateWithdrawalToTeam()
 
@@ -58,6 +60,8 @@ type IExtendedAgent interface {
 	CreateScoreReportMessage() *ScoreReportMessage
 	CreateContributionMessage(statedAmount int) *ContributionMessage
 	CreateWithdrawalMessage(statedAmount int) *WithdrawalMessage
+	CreateOpinionRequestMessage(agentID uuid.UUID) *OpinionRequestMessage
+	CreateOpinionResponseMessage(agentID uuid.UUID, opinion int) *OpinionResponseMessage
 	LogSelfInfo()
 	GetAoARanking() []int
 	SetAoARanking(Preferences []int)

--- a/common/MessageTypes.go
+++ b/common/MessageTypes.go
@@ -29,15 +29,15 @@ type WithdrawalMessage struct {
 	ExpectedAmount int
 }
 
-type OpinionRequestMessage struct {
+type AgentOpinionRequestMessage struct {
 	message.BaseMessage
 	AgentID uuid.UUID
 }
 
-type OpinionResponseMessage struct {
+type AgentOpinionResponseMessage struct {
 	message.BaseMessage
-	AgentID uuid.UUID
-	Opinion int
+	AgentID      uuid.UUID
+	AgentOpinion int
 }
 
 func (msg *TeamFormationMessage) InvokeMessageHandler(agent IExtendedAgent) {
@@ -56,10 +56,10 @@ func (msg *WithdrawalMessage) InvokeMessageHandler(agent IExtendedAgent) {
 	agent.HandleWithdrawalMessage(msg)
 }
 
-func (msg *OpinionRequestMessage) InvokeMessageHandler(agent IExtendedAgent) {
-	agent.HandleOpinionRequestMessage(msg)
+func (msg *AgentOpinionRequestMessage) InvokeMessageHandler(agent IExtendedAgent) {
+	agent.HandleAgentOpinionRequestMessage(msg)
 }
 
-func (msg *OpinionResponseMessage) InvokeMessageHandler(agent IExtendedAgent) {
-	agent.HandleOpinionResponseMessage(msg)
+func (msg *AgentOpinionResponseMessage) InvokeMessageHandler(agent IExtendedAgent) {
+	agent.HandleAgentOpinionResponseMessage(msg)
 }

--- a/common/MessageTypes.go
+++ b/common/MessageTypes.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"github.com/MattSScott/basePlatformSOMAS/v2/pkg/message"
+	"github.com/google/uuid"
 )
 
 type TeamFormationMessage struct {
@@ -28,6 +29,17 @@ type WithdrawalMessage struct {
 	ExpectedAmount int
 }
 
+type OpinionRequestMessage struct {
+	message.BaseMessage
+	AgentID uuid.UUID
+}
+
+type OpinionResponseMessage struct {
+	message.BaseMessage
+	AgentID uuid.UUID
+	Opinion int
+}
+
 func (msg *TeamFormationMessage) InvokeMessageHandler(agent IExtendedAgent) {
 	agent.HandleTeamFormationMessage(msg)
 }
@@ -42,4 +54,12 @@ func (msg *ContributionMessage) InvokeMessageHandler(agent IExtendedAgent) {
 
 func (msg *WithdrawalMessage) InvokeMessageHandler(agent IExtendedAgent) {
 	agent.HandleWithdrawalMessage(msg)
+}
+
+func (msg *OpinionRequestMessage) InvokeMessageHandler(agent IExtendedAgent) {
+	agent.HandleOpinionRequestMessage(msg)
+}
+
+func (msg *OpinionResponseMessage) InvokeMessageHandler(agent IExtendedAgent) {
+	agent.HandleOpinionResponseMessage(msg)
 }


### PR DESCRIPTION
Agent Opinion Messaging allows agents to asynchronously gather information about another agent that they have newly discovered (maybe been paired up with from the first time), or in general to make more informed decision (maybe related to auditing, whether to accept them into their team, etc). This is a QoL feature which may help dispense information that isn't easy to dispense otherwise, and provides a uniform framework for all team to override and build upon.