### PR TITLE
BugFix - StateContributionToTeam and StateWithdrawalToTeam

### DIFF
--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -362,16 +362,16 @@ func (mi *ExtendedAgent) BroadcastSyncMessageToTeam(msg message.IMessage[common.
 	}
 }
 
-func (mi *ExtendedAgent) StateContributionToTeam() {
+func (mi *ExtendedAgent) StateContributionToTeam(instance common.IExtendedAgent) {
 	// Broadcast contribution to team
-	statedContribution := mi.GetStatedContribution(mi)
+	statedContribution := instance.GetStatedContribution(instance)
 	contributionMsg := mi.CreateContributionMessage(statedContribution)
 	mi.BroadcastSyncMessageToTeam(contributionMsg)
 }
 
-func (mi *ExtendedAgent) StateWithdrawalToTeam() {
+func (mi *ExtendedAgent) StateWithdrawalToTeam(instance common.IExtendedAgent) {
 	// Broadcast withdrawal to team
-	statedWithdrawal := mi.GetStatedWithdrawal(mi)
+	statedWithdrawal := instance.GetStatedWithdrawal(instance)
 	withdrawalMsg := mi.CreateWithdrawalMessage(statedWithdrawal)
 	mi.BroadcastSyncMessageToTeam(withdrawalMsg)
 }

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -52,8 +52,8 @@ type IExtendedAgent interface {
 	HandleContributionMessage(msg *ContributionMessage)
 	HandleAgentOpinionRequestMessage(msg *AgentOpinionRequestMessage)
 	HandleAgentOpinionResponseMessage(msg *AgentOpinionResponseMessage)
-	StateContributionToTeam()
-	StateWithdrawalToTeam()
+	StateContributionToTeam(instance IExtendedAgent)
+	StateWithdrawalToTeam(instance IExtendedAgent)
 
 	// Info
 	GetExposedInfo() ExposedAgentInfo

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -65,7 +65,7 @@ func (cs *EnvironmentServer) RunTurn(i, j int) {
 			agentContributionsTotal += agentActualContribution
 			agentStatedContribution := agent.GetStatedContribution(agent)
 
-			agent.StateContributionToTeam()
+			agent.StateContributionToTeam(agent)
 			agentScore := agent.GetTrueScore()
 			// Update audit result for this agent
 			team.TeamAoA.SetContributionAuditResult(agentID, agentScore, agentActualContribution, agentStatedContribution)
@@ -133,7 +133,7 @@ func (cs *EnvironmentServer) RunTurn(i, j int) {
 			if agent.GetTeamID() == uuid.Nil || cs.IsAgentDead(agentId) {
 				continue
 			}
-			agent.StateWithdrawalToTeam()
+			agent.StateWithdrawalToTeam(agent)
 		}
 
 		// Initiate Withdrawal Audit vote


### PR DESCRIPTION
## BugFix - StateContributionToTeam and StateWithdrawalToTeam
- call child/overriden implementation instead of base implementation

This fixes a bug where derived agents were stating a different contribution/withdrawal than they stated to the server