### PR TITLE
Add Get Teams method to the server

### DIFF
--- a/common/IServer.go
+++ b/common/IServer.go
@@ -19,6 +19,7 @@ type IServer interface {
 
 	GetTeam(agentID uuid.UUID) *Team
 	GetTeamFromTeamID(teamID uuid.UUID) *Team
+	GetTeams() []uuid.UUID
 
 	// Debug functions
 	LogAgentStatus()

--- a/common/IServer.go
+++ b/common/IServer.go
@@ -20,6 +20,7 @@ type IServer interface {
 	GetTeam(agentID uuid.UUID) *Team
 	GetTeamFromTeamID(teamID uuid.UUID) *Team
 	GetTeams() []uuid.UUID
+	GetTeamCommonPool(teamID uuid.UUID) int
 
 	// Debug functions
 	LogAgentStatus()

--- a/common/IServer.go
+++ b/common/IServer.go
@@ -19,7 +19,7 @@ type IServer interface {
 
 	GetTeam(agentID uuid.UUID) *Team
 	GetTeamFromTeamID(teamID uuid.UUID) *Team
-	GetTeams() []uuid.UUID
+	GetTeamIDs() []uuid.UUID
 	GetTeamCommonPool(teamID uuid.UUID) int
 
 	// Debug functions

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -642,7 +642,7 @@ func (cs *EnvironmentServer) GetTeamFromTeamID(teamID uuid.UUID) *common.Team {
 }
 
 // To be used by agents to find out what teams they want to join in the next round (if they are orphaned).
-func (cs *EnvironmentServer) GetTeams() []uuid.UUID {
+func (cs *EnvironmentServer) GetTeamIDs() []uuid.UUID {
 	teamIDs := make([]uuid.UUID, 0, len(cs.Teams))
 	for teamID := range cs.Teams {
 		teamIDs = append(teamIDs, teamID)

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -641,6 +641,15 @@ func (cs *EnvironmentServer) GetTeamFromTeamID(teamID uuid.UUID) *common.Team {
 	return cs.Teams[teamID]
 }
 
+// To be used by agents to find out what teams they want to join in the next round (if they are orphaned).
+func (cs *EnvironmentServer) GetTeams() []uuid.UUID {
+	teamIDs := make([]uuid.UUID, 0, len(cs.Teams))
+	for teamID := range cs.Teams {
+		teamIDs = append(teamIDs, teamID)
+	}
+	return teamIDs
+}
+
 // reset all agents (preserve memory but clears scores)
 func (cs *EnvironmentServer) ResetAgents() {
 	for _, agent := range cs.GetAgentMap() {

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -650,6 +650,14 @@ func (cs *EnvironmentServer) GetTeams() []uuid.UUID {
 	return teamIDs
 }
 
+// Can be used to find the amount in the common pool for a team. If this is used,
+// it should be logged on the server (to prevent cheating)
+func (cs *EnvironmentServer) GetTeamCommonPool(teamID uuid.UUID) int {
+	log.Printf("Get Team Common Pool called! Team ID: %v\n", teamID)
+	team := cs.Teams[teamID]
+	return team.GetCommonPool()
+}
+
 // reset all agents (preserve memory but clears scores)
 func (cs *EnvironmentServer) ResetAgents() {
 	for _, agent := range cs.GetAgentMap() {


### PR DESCRIPTION
Currently, agents have no way of accessing data about teams on the server. Ideally, they would have enough information to make an informed decision about the next team they would like to join (in case they are orphaned). This includes:

- Team common pool amount (Added with this PR)
- Agents within a team (There is a way to do this)

Additionally, currently agents have no way of knowing the team IDs currently existing on the server. If they do, feel free to comment on it and I'll close this PR. 

To keep it fair, I would say this function should only be used to decide orphan logic, and not to jump ship if another team is doing better. This can be enforced by returning the team IDs, and methods on the server to return the common pool amount for a particular team. And even then, the common pool information should be used in a fair manner within agent strategies.