### PR TITLE
Ask agents if they want to leave/Enable server to kick them to enforce a punishment

### DIFF
--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -223,6 +223,12 @@ func (mi *ExtendedAgent) GetStatedWithdrawal(instance common.IExtendedAgent) int
 	return instance.GetActualContribution(instance)
 }
 
+func (mi *ExtendedAgent) GetLeaveOpinion(instance common.IExtendedAgent) bool {
+	// Currently defaulted to false. If called on itself, won't this go into an infinite loop?
+	// return mi.GetLeaveOpinion(instance)
+	return false
+}
+
 /*
 Provide agentId for memory, current accumulated score
 (to see if above or below predicted threshold for common pool contribution)

--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -223,10 +223,18 @@ func (mi *ExtendedAgent) GetStatedWithdrawal(instance common.IExtendedAgent) int
 	return instance.GetActualContribution(instance)
 }
 
-func (mi *ExtendedAgent) GetLeaveOpinion(instance common.IExtendedAgent) bool {
-	// Currently defaulted to false. If called on itself, won't this go into an infinite loop?
-	// return mi.GetLeaveOpinion(instance)
-	return false
+/*
+ * Ask an agent if it wants to leave or not. "Opinion" because there
+ * should be logic on the server to prevent agents from leaving if they
+ * are currently being punished as a result of an audit.
+ */
+func (mi *ExtendedAgent) GetLeaveOpinion(agentID uuid.UUID) bool {
+	// Recursion block
+	if mi.GetID() == agentID {
+		return false
+	}
+	// Get the underlying agent's opinion
+	return mi.Server.AccessAgentByID(agentID).GetLeaveOpinion(mi.GetID())
 }
 
 /*

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -25,7 +25,7 @@ type IExtendedAgent interface {
 	GetActualWithdrawal(instance IExtendedAgent) int
 	GetStatedContribution(instance IExtendedAgent) int
 	GetStatedWithdrawal(instance IExtendedAgent) int
-	GetLeaveOpinion(instance IExtendedAgent) bool
+	GetLeaveOpinion(agentID uuid.UUID) bool
 
 	// Setters
 	SetTeamID(teamID uuid.UUID)

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -25,6 +25,7 @@ type IExtendedAgent interface {
 	GetActualWithdrawal(instance IExtendedAgent) int
 	GetStatedContribution(instance IExtendedAgent) int
 	GetStatedWithdrawal(instance IExtendedAgent) int
+	GetLeaveOpinion(instance IExtendedAgent) bool
 
 	// Setters
 	SetTeamID(teamID uuid.UUID)

--- a/common/Team2AoA.go
+++ b/common/Team2AoA.go
@@ -16,7 +16,6 @@ import (
  * TODO:
  * - Write some tests for the audit functionality here
  * - Implement the functionality on the server to work with this (so with offences)
- * - Implement the kick functionality on the server
  * - Make sure that if the leader dies, or is audited, they have to be re-elected
  */
 
@@ -133,9 +132,11 @@ func (t *Team2AoA) GetVoteResult(votes []Vote) uuid.UUID {
 	if len(votes) == 0 {
 		return uuid.Nil
 	}
+
 	voteMap := make(map[uuid.UUID]int)
 	duration := 0
 	count := len(t.Team.Agents)
+
 	for _, vote := range votes {
 		durationVote, agentVotedFor := vote.AuditDuration, vote.VotedForID
 		votes := 1
@@ -148,13 +149,18 @@ func (t *Team2AoA) GetVoteResult(votes []Vote) uuid.UUID {
 		}
 		duration += durationVote
 	}
+
 	duration /= len(votes)
-	t.auditRecord.SetAuditDuration(duration)
+	if duration > 0 {
+		t.auditRecord.SetAuditDuration(duration)
+	}
+
 	for votedFor, votes := range voteMap {
 		if votes >= ((count / 2) + 1) {
 			return votedFor
 		}
 	}
+
 	return uuid.Nil
 }
 

--- a/common/team.go
+++ b/common/team.go
@@ -24,6 +24,15 @@ func (team *Team) SetCommonPool(amount int) {
 	team.commonPool = amount
 }
 
+func (team *Team) RemoveAgent(agentID uuid.UUID) {
+	for i, a := range team.Agents {
+		if a == agentID {
+			team.Agents = append(team.Agents[:i], team.Agents[i+1:]...)
+			break
+		}
+	}
+}
+
 // constructor: NewTeam creates a new Team with a unique TeamID and initializes other fields as blank.
 func NewTeam(teamID uuid.UUID) *Team {
 	teamAoA := CreateFixedAoA(1)

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -888,10 +888,10 @@ func (cs *EnvironmentServer) RemoveAgentFromTeam(agentID uuid.UUID) {
 	team.RemoveAgent(agentID)
 }
 
-// Ask all the agents in if they want to leave the team they are in or not. Ignore dead agents
+// Ask all the agents if they want to leave the team they are in or not. Ignore dead agents
 func (cs *EnvironmentServer) ProcessAgentsLeaving() {
 	for agentID, agent := range cs.GetAgentMap() {
-		if !cs.IsAgentDead(agentID) && agent.GetLeaveOpinion(agent) {
+		if !cs.IsAgentDead(agentID) && agent.GetLeaveOpinion(agentID) {
 			cs.RemoveAgentFromTeam(agentID)
 		}
 	}


### PR DESCRIPTION
- Asks agents in each team if they would like to leave. If the orphan pool works as I understand it, the moment the agents don't have a team they are picked up. @nlewxxs would be nice if you could confirm this
- Added `RemoveAgentFromTeam` which can be used to kick agents from the team as well.
- Add method within agents asking if they want to leave. Default behaviour is set to `false`.

Addresses #26 

Pending: Enforcing a check on the agents to force them to stay if they are currently under punishment from a successful audit (Maybe as another PR if we have the time).