### PR TITLE
Agent Names

### DIFF
--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -21,7 +21,7 @@ type ExtendedAgent struct {
 	Server common.IServer
 	Score  int
 	TeamID uuid.UUID
-	Name int
+	Name   int
 
 	// private
 	LastScore int
@@ -91,7 +91,7 @@ func (mi *ExtendedAgent) SetTrueScore(score int) {
 	mi.Score = score
 }
 
-func (mi *ExtendedAgent) SetName(name int){
+func (mi *ExtendedAgent) SetName(name int) {
 	mi.Name = name
 }
 
@@ -229,7 +229,7 @@ func (mi *ExtendedAgent) GetStatedWithdrawal(instance common.IExtendedAgent) int
 }
 
 func (mi *ExtendedAgent) GetName() int {
-	return mi.Name 
+	return mi.Name
 }
 
 /*

--- a/agents/ExtendedAgent.go
+++ b/agents/ExtendedAgent.go
@@ -21,6 +21,7 @@ type ExtendedAgent struct {
 	Server common.IServer
 	Score  int
 	TeamID uuid.UUID
+	Name int
 
 	// private
 	LastScore int
@@ -88,6 +89,10 @@ func (mi *ExtendedAgent) GetTrueSomasTeamID() int {
 // Setter for the server to call, in order to set the true score for this agent
 func (mi *ExtendedAgent) SetTrueScore(score int) {
 	mi.Score = score
+}
+
+func (mi *ExtendedAgent) SetName(name int){
+	mi.Name = name
 }
 
 // custom function: ask for rolling the dice
@@ -221,6 +226,10 @@ func (mi *ExtendedAgent) GetStatedWithdrawal(instance common.IExtendedAgent) int
 	}
 	// Currently, assume stated withdrawal matches actual withdrawal
 	return instance.GetActualContribution(instance)
+}
+
+func (mi *ExtendedAgent) GetName() int {
+	return mi.Name 
 }
 
 /*

--- a/common/IExtendedAgent.go
+++ b/common/IExtendedAgent.go
@@ -17,6 +17,7 @@ type IExtendedAgent interface {
 	GetLastTeamID() uuid.UUID
 	GetTrueScore() int
 	GetTeamRanking() []uuid.UUID
+	GetName() int
 
 	// Functions that involve strategic decisions
 	StartTeamForming(instance IExtendedAgent, agentInfoList []ExposedAgentInfo)
@@ -27,6 +28,7 @@ type IExtendedAgent interface {
 	GetStatedWithdrawal(instance IExtendedAgent) int
 
 	// Setters
+	SetName(name int)
 	SetTeamID(teamID uuid.UUID)
 	SetTrueScore(score int)
 	SetAgentContributionAuditResult(agentID uuid.UUID, result bool)

--- a/main.go
+++ b/main.go
@@ -70,7 +70,8 @@ func main() {
 		// Add other teams' agents here
 	}
 
-	for _, agent := range agentPopulation {
+	for i, agent := range agentPopulation {
+		agent.SetName(i)
 		serv.AddAgent(agent)
 	}
 


### PR DESCRIPTION
Created a function called GetName that can be used instead of GetID in Logs/Prints for readability. 
The names are given to the agents at the server entry by order. The first agent that enters the server is called 1, the second is called 2...
I am happy to update the logs/prints with this function on Thursday morning if this pull request gets approved 