### PR TITLE
Fix Team Common Pool being reset to 0 per n threshold turns

### DIFF
--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -581,9 +581,9 @@ func (cs *EnvironmentServer) allocateAoAs() {
 }
 
 func (cs *EnvironmentServer) RunEndOfIteration(int) {
-	// for _, agent := range cs.GetAgentMap() {
-	// 	cs.killAgentBelowThreshold(agent.GetID())
-	// }
+	for _, team := range cs.Teams {
+		team.SetCommonPool(0)
+	}
 }
 
 // custom override (what why this is called later then start iteration...)

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -877,9 +877,6 @@ func (cs *EnvironmentServer) ResetAgents() {
 
 func (cs *EnvironmentServer) ApplyThreshold() {
 	cs.thresholdAppliedInTurn = true
-	for _, team := range cs.Teams {
-		team.SetCommonPool(0)
-	}
 
 	for _, agent := range cs.GetAgentMap() {
 		cs.killAgentBelowThreshold(agent.GetID())


### PR DESCRIPTION
Every teams common pool was being reset to 0 within turns - should only happen at the beginning/end of an iteration