### PR TITLE
Emergency Safety Check 

### DIFF
--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -48,7 +48,7 @@ func (cs *EnvironmentServer) RunTurnDefault(team *common.Team) {
 	agentContributionsTotal := 0
 	for _, agentID := range team.Agents {
 		agent := cs.GetAgentMap()[agentID]
-		if agent.GetTeamID() == uuid.Nil || cs.IsAgentDead(agentID) {
+		if agent == nil || agent.GetTeamID() == uuid.Nil || cs.IsAgentDead(agentID) {
 			continue
 		}
 
@@ -108,7 +108,7 @@ func (cs *EnvironmentServer) RunTurnDefault(team *common.Team) {
 	orderedAgents := team.TeamAoA.GetWithdrawalOrder(team.Agents)
 	for _, agentID := range orderedAgents {
 		agent := cs.GetAgentMap()[agentID]
-		if agent.GetTeamID() == uuid.Nil || cs.IsAgentDead(agentID) {
+		if agent == nil || agent.GetTeamID() == uuid.Nil || cs.IsAgentDead(agentID) {
 			continue
 		}
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/894ab76c-17d9-47e0-9496-98700e40b0ef)

Not sure why this is happening, but an agent is requested from the map in a rare case when it has already been removed (likely already dead).

This fix is a safeguard against a crash during the demo.