### PR TITLE
Fix Override Dice Rolls

### DIFF
--- a/server/Team2Server.go
+++ b/server/Team2Server.go
@@ -82,6 +82,13 @@ func (cs *EnvironmentServer) ElectNewLeader(teamId uuid.UUID) {
 func (cs *EnvironmentServer) OverrideAgentRolls(agentId uuid.UUID, leaderId uuid.UUID) {
 	controlled := cs.GetAgentMap()[agentId]
 	leader := cs.GetAgentMap()[leaderId]
+
+	if leader == nil {
+		log.Printf("Leader with ID %v not found", leaderId)
+		cs.ElectNewLeader(agentId)
+		return
+	}
+
 	currentScore, accumulatedScore := controlled.GetTrueScore(), 0
 	prevRoll := -1
 	rounds := 0


### PR DESCRIPTION
Rare case where there is no leader assigned, and there is a punishment assigned immediately, there is a seg fault since the leader cannot be found. This should logically not really be happening, but another safeguard so that if the leader is nil, we just elect one and return immediately.