### PR TITLE
final update on visualization page

### DIFF
--- a/agents/MI_256_v1.go
+++ b/agents/MI_256_v1.go
@@ -1,7 +1,8 @@
 package agents
 
 import (
-	"log"
+	"fmt"
+	"math"
 	"math/rand"
 
 	common "github.com/ADimoska/SOMASExtended/common"
@@ -12,21 +13,221 @@ import (
 
 type MI_256_v1 struct {
 	*ExtendedAgent
+
+	//character matrix:
+	chaoticness int // from 1 to 3, 3 being most chaotic
+	evilness    int // from 1 to 3, 3 being most evil
+
+	//opinions
+	affinity map[uuid.UUID]int // has opinions for each agent in the game
+	mood     int               // starting from 0
+
+	affinityChange map[uuid.UUID]int // the total change in affinity this turn
+
+	// store of other character's states (what the id of the agents in the team )
+	teamAgentsDeclaredRolls        map[uuid.UUID]int
+	teamAgentsDeclaredContribution map[uuid.UUID]int
+	teamAgentsDeclaredWithdraw     map[uuid.UUID]int
+	teamAgentsExpectedScore        map[uuid.UUID]int
+
+	teamAgentsExpectedContribution map[uuid.UUID]int
+	teamAgentsExpectedWithdraw     map[uuid.UUID]int
+
+	// store of the other character's states during an audit
+	lastAuditTarget  uuid.UUID
+	lastVotes        map[uuid.UUID]bool
+	lastAuditStarter uuid.UUID
+	lastAuditResult  bool
+
+	// TODO: internal states
+
+	// Information I need
+	last_common_pool int
+
+	//AOA parameterss
+	AOAOpinion              map[uuid.UUID]int
+	AoAExpectedContribution int
+	AoAExpectedWithdrawal   int
+	AoAAuditCost            int
+	AoAPunishment           int
+
+	isAoAContributionFixed bool
+	isAoAWithdrawalFixed   bool
+
+	//Intended Withdrawal and Contribution
+	IntendedWithdrawal   int
+	declaredWithdrawal   int
+	intendedContribution int
+	declaredcontribution int
+
+	isThereCheatWithdrawal   bool
+	cheatWithdrawalDiff      int
+	isThereCheatContribution bool
+	cheatContributeDiff      int
+	haveIlied                bool
+	IcaughtLying             bool
+
+	lastThreshold int
+	lastTurnScore int
 }
 
-// Constructor for MI_256_v1
+func (mi *MI_256_v1) print_alignment() {
+	fmt.Println(mi.GetID(), " has been created. Chaoticness:", mi.chaoticness, "Evilness:", mi.evilness)
+}
+
+// constructor for MI_256_v1
 func Team4_CreateAgent(funcs agent.IExposedServerFunctions[common.IExtendedAgent], agentConfig AgentConfig) *MI_256_v1 {
 	mi_256 := &MI_256_v1{
 		ExtendedAgent: GetBaseAgents(funcs, agentConfig),
 	}
 	mi_256.TrueSomasTeamID = 4 // IMPORTANT: add your team number here!
+	mi_256.RandomizeCharacter()
+	mi_256.teamAgentsDeclaredRolls = make(map[uuid.UUID]int)
+	mi_256.teamAgentsDeclaredContribution = make(map[uuid.UUID]int)
+	mi_256.teamAgentsDeclaredWithdraw = make(map[uuid.UUID]int)
+	mi_256.teamAgentsExpectedScore = make(map[uuid.UUID]int)
+	mi_256.teamAgentsExpectedContribution = make(map[uuid.UUID]int)
+	mi_256.teamAgentsExpectedWithdraw = make(map[uuid.UUID]int)
+	mi_256.affinity = make(map[uuid.UUID]int)
+	mi_256.affinityChange = make(map[uuid.UUID]int)
+
+	fmt.Println(mi_256.GetID(), " has been created. Chaoticness:", mi_256.chaoticness, "Evilness:", mi_256.evilness)
 	return mi_256
 }
 
+// ----------------------- Function Override -----------------------
+func (mi *MI_256_v1) SetAgentContributionAuditResult(agentID uuid.UUID, result bool) {
+	mi.lastAuditTarget = agentID
+	mi.lastAuditResult = result
+}
+
+func (mi *MI_256_v1) SetAgentWithdrawalAuditResult(agentID uuid.UUID, result bool) {
+	mi.lastAuditTarget = agentID
+	mi.lastAuditResult = result
+}
+
+// ----functions to calculate the data of other team members------------
+func (mi *MI_256_v1) UpdateTeamDeclaredContribution() {
+	for _, agent := range mi.Server.GetTeam(mi.GetID()).Agents {
+		mi.teamAgentsDeclaredContribution[agent] = mi.GetStatedContribution(mi.Server.AccessAgentByID(agent))
+		// numAgent += 1
+	}
+}
+func (mi *MI_256_v1) UpdateTeamDeclaredWithdrawal() {
+	for _, agent := range mi.Server.GetTeam(mi.GetID()).Agents {
+		mi.teamAgentsDeclaredWithdraw[agent] = mi.GetStatedWithdrawal(mi.Server.AccessAgentByID(agent))
+		// numAgent += 1
+	}
+}
+
+func (mi *MI_256_v1) Team4_UpdateStateAfterContribution() {
+	mi.UpdateTeamDeclaredContribution()
+	mi.UpdateAffinityAfterContribute()
+
+}
+func (mi *MI_256_v1) Team4_UpdateStateAfterWithdrawal() {
+	mi.UpdateTeamDeclaredWithdrawal()
+	mi.UpdateAffinityAfterWithdraw()
+
+}
+func (mi *MI_256_v1) Team4_UpdateStateAfterContributionAudit() {
+	mi.UpdateAffinityAfterVote()
+	mi.UpdateAffinityAfterAudit()
+
+}
+func (mi *MI_256_v1) Team4_UpdateStateAfterWithdrawalAudit() {
+	mi.UpdateAffinityAfterVote()
+	mi.UpdateAffinityAfterAudit()
+	mi.UpdateMoodAfterAuditionEnd()
+
+}
+func (mi *MI_256_v1) Team4_UpdateStateAfterRoll() {
+	mi.UpdateMoodAfterRoll()
+
+}
+func (mi *MI_256_v1) Team4_UpdateStateTurnend() {
+	mi.UpdateMoodAfterRoundEnd()
+	mi.lastTurnScore = mi.Score
+
+}
+
+//------functions to calculated the expected AOA contributions and stuff for all agents -------------------------------
+
+func (mi *MI_256_v1) CalcAOAContibution() int {
+
+	// mi.AoAExpectedContribution = int(0.5 * float64(mi.Score))
+
+	mi.AoAExpectedContribution = mi.Server.GetTeam(mi.GetID()).TeamAoA.GetExpectedContribution(mi.GetID(), mi.GetTrueScore())
+	fmt.Println(mi.GetID(), " the expected contribution is:", mi.AoAExpectedContribution)
+	mi.isAoAContributionFixed = true
+	return mi.AoAExpectedContribution
+
+}
+func (mi *MI_256_v1) CalcAOAWithdrawal() int {
+	// common_pool := mi.Server.GetTeam(mi.GetID()).GetCommonPool()
+
+	// mi.AoAExpectedWithdrawal = int(common_pool / (len(mi.Server.GetTeam(mi.GetID()).Agents) + 1))
+	mi.AoAExpectedWithdrawal = mi.Server.GetTeam(mi.GetID()).TeamAoA.GetExpectedWithdrawal(mi.GetID(), mi.GetTrueScore(), mi.Server.GetTeamCommonPool(mi.GetTeamID()))
+
+	fmt.Println(mi.GetID(), " the expected withdrawal is:", mi.AoAExpectedWithdrawal)
+	mi.isAoAWithdrawalFixed = true
+
+	return mi.AoAExpectedWithdrawal
+}
+func (mi *MI_256_v1) CalcAOAAuditCost() {
+
+}
+func (mi *MI_256_v1) CalcAOAPunishment() {
+
+}
+func (mi *MI_256_v1) CalcAOAOpinion() {
+
+}
+func (mi *MI_256_v1) SetAoARanking(Preferences []int) {
+	mi.AoARanking = Preferences
+}
+
 // ----------------------- Strategies -----------------------
+
+func (mi *MI_256_v1) AnyoneCheatedAfterContribute() {
+	common_pool := mi.Server.GetTeam(mi.GetID()).GetCommonPool()
+	change := common_pool - mi.last_common_pool
+	mi.last_common_pool = common_pool
+	sum := 0
+	for _, agent := range mi.Server.GetTeam(mi.GetID()).Agents {
+		sum += mi.teamAgentsDeclaredContribution[agent]
+		// numAgent += 1
+	}
+	if sum != change {
+		mi.isThereCheatContribution = true
+	} else {
+		mi.isThereCheatContribution = false
+	}
+	mi.cheatContributeDiff = sum - change
+
+	// get common pool before and after contribution, compare with the total declared contribution, to see if there is a cheat this round
+
+}
+func (mi *MI_256_v1) AnyoneCheatedAfterWithdrawal() {
+	common_pool := mi.Server.GetTeam(mi.GetID()).GetCommonPool()
+	change := common_pool - mi.last_common_pool
+	mi.last_common_pool = common_pool
+	sum := 0
+	for _, agent := range mi.Server.GetTeam(mi.GetID()).Agents {
+		sum += mi.teamAgentsDeclaredWithdraw[agent]
+		// numAgent += 1
+	}
+	if sum != change {
+		mi.isThereCheatWithdrawal = true
+	} else {
+		mi.isThereCheatWithdrawal = false
+	}
+	mi.cheatWithdrawalDiff = sum - change
+
+}
+
 // Team-forming Strategy
 func (mi *MI_256_v1) DecideTeamForming(agentInfoList []common.ExposedAgentInfo) []uuid.UUID {
-	log.Printf("Called overriden DecideTeamForming\n")
 	invitationList := []uuid.UUID{}
 	for _, agentInfo := range agentInfoList {
 		// exclude the agent itself
@@ -36,6 +237,7 @@ func (mi *MI_256_v1) DecideTeamForming(agentInfoList []common.ExposedAgentInfo) 
 		if agentInfo.AgentTeamID == (uuid.UUID{}) {
 			invitationList = append(invitationList, agentInfo.AgentUUID)
 		}
+
 	}
 
 	// TODO: implement team forming logic
@@ -49,93 +251,923 @@ func (mi *MI_256_v1) DecideTeamForming(agentInfoList []common.ExposedAgentInfo) 
 
 // Dice Strategy
 func (mi *MI_256_v1) StickOrAgain(accumulatedScore int, prevRoll int) bool {
-	log.Printf("Called overriden StickOrAgain\n")
-	// TODO: implement dice strategy
-	return true
+
+	// fmt.Printf("Called overriden StickOrAgain\n")
+
+	// the higher the mood, the more risky the roll dice strategy will be
+
+	threshLow := 9
+	threshMid := 12
+	threshHigh := 14
+	moodthresh := 10
+	if mi.mood > moodthresh { // be greedy
+		if mi.LastScore < threshHigh {
+			return false
+		} else {
+			return true
+		}
+	} else if (-moodthresh < mi.mood) && (mi.mood < moodthresh) {
+		if mi.LastScore < threshMid {
+			return false
+		} else {
+			return true
+		}
+	} else {
+		if mi.LastScore < threshLow {
+			return false
+		} else {
+			return true
+		}
+	}
+
 }
 
 // !!! NOTE: name and signature of functions below are subject to change by the infra team !!!
 
+// definition of Evilness: The more he would value his own benifit over others.
+// definition of Chaoticness: The willingness to take risk to breach the AoA
+// definition of Mood: The willingness to take actions which diverges from abosolute neutral
 // Contribution Strategy
 func (mi *MI_256_v1) DecideContribution() int {
-	// TODO: implement contribution strategy
-	return 1
+	mi.CalcAOAContibution()
+	if mi.Score == 0 || mi.AoAExpectedContribution == 0 {
+		mi.intendedContribution = 0
+		mi.declaredcontribution = 0
+		return 0
+
+	}
+
+	//parameters: AoAExpectedContribution, Mood, Lawfulness,Evilness，  CurrentScore
+	mi.intendedContribution = 0
+	contribute_percentage := 0.0
+	// CurrentScore = mi.Score
+
+	mood_modifier := float64(1.0 / 100.0 * float64(mi.mood))
+	neutral_mean := (float64(mi.AoAExpectedContribution) / float64(min(mi.Score, 2*mi.AoAExpectedContribution))) //normalize from 0-1
+	//we model evil and good with different standard deviations, with chaotic being high standard deviation,
+	lawful_evil_mean := neutral_mean * 5 / 8
+	neutral_evil_mean := neutral_mean * 2 / 4
+	neutral_good_mean := (1-neutral_mean)/2 + neutral_mean
+	lawful_good_mean := float64(7.0 / 8)
+	neutral_standard_deviation := float64(1.0 / 12)
+	lawful_standard_deviation := 1.0 / 16.0
+	chaotic_standard_deviation := 1.0 / 8
+	chaotic_good_standard_deviation := 3.0 / 8 * (1 - neutral_mean)
+	chaotic_evil_standard_deviation := 3.0 / 8 * neutral_mean
+	neutral_good_standard_deviation := 1.0 / 8 * (1 - neutral_mean)
+	neutral_evil_standard_deviation := 1.0 / 8 * neutral_mean
+	lawful_good_standard_deviation := 1.0 / 16 * (1 - neutral_mean)
+	lawful_evil_standard_deviation := 1.0 / 16 * neutral_mean
+	// fmt.Println(mi.GetID(), " neutral_mean", neutral_mean)
+	// fmt.Println(mi.GetID(), " lawful_evil_mean", lawful_evil_mean)
+	// fmt.Println(mi.GetID(), " neutral_evil_mean", neutral_evil_mean)
+
+	Apply_mood := func(contribute_percentage float64) float64 {
+		if contribute_percentage > float64(neutral_mean) {
+			return contribute_percentage + mood_modifier
+		} else {
+			return contribute_percentage - mood_modifier
+		}
+	}
+
+	// if the agent is a lawful agent, he would tend to not break the AoA
+	// if the agent is a good agent, he would tend to contribute more than he should
+	// absolute neutral: donating as much as the AoA asks.
+
+	// we set a linear specturm for the strategies and calculate where we would end up in this scale
+	//
+	// Each personality would have a mean on that scale, and would have standard deviations based on the chaoticness
+
+	if mi.evilness == 2 { // if agent has neutral evilness, use neutral mean
+		if mi.chaoticness == 1 { // if lawful neutral
+
+			contribute_percentage = (rand.NormFloat64() * float64(lawful_standard_deviation)) + float64(neutral_mean)
+
+		} else if mi.chaoticness == 2 { // abs neutral
+			contribute_percentage = (rand.NormFloat64() * float64(neutral_standard_deviation)) + float64(neutral_mean)
+
+		} else if mi.chaoticness == 3 { //chaotic neutral
+			contribute_percentage = (rand.NormFloat64() * float64(chaotic_standard_deviation)) + float64(neutral_mean)
+
+		}
+
+	} else if mi.evilness == 1 { // if agent is good
+		if mi.chaoticness == 1 { // if lawful good
+
+			contribute_percentage = (rand.NormFloat64() * float64(lawful_good_standard_deviation)) + float64(lawful_good_mean)
+
+		} else if mi.chaoticness == 2 { // neutral good
+			contribute_percentage = (rand.NormFloat64() * float64(neutral_good_standard_deviation)) + float64(neutral_good_mean)
+
+		} else if mi.chaoticness == 3 { //chaotic good
+			contribute_percentage = (rand.NormFloat64() * float64(chaotic_good_standard_deviation)) + float64(neutral_good_mean)
+
+		}
+
+	} else if mi.evilness == 3 { // if agent is evil
+		if mi.chaoticness == 1 { // if lawful evil
+
+			contribute_percentage = (rand.NormFloat64() * float64(lawful_evil_standard_deviation)) + float64(lawful_evil_mean)
+
+		} else if mi.chaoticness == 2 { // neutral evil
+			contribute_percentage = (rand.NormFloat64() * float64(neutral_evil_standard_deviation)) + float64(neutral_evil_mean)
+
+		} else if mi.chaoticness == 3 { //chaotic evil
+			contribute_percentage = (rand.NormFloat64() * float64(chaotic_evil_standard_deviation)) + float64(neutral_evil_mean)
+
+		}
+	}
+	contribute_percentage = Apply_mood(contribute_percentage)
+	fmt.Println(mi.GetID(), " contribution percentage", contribute_percentage)
+	mi.print_alignment()
+	mi.intendedContribution = min(max(int(math.Round(float64(contribute_percentage)*float64(min(mi.Score, 2*mi.AoAExpectedContribution)))), 0), mi.Score)
+
+	// how much to declare:
+	// if you contributed less, there is no point to lie ( if audition checks against the expected contribution)
+	if mi.isAoAContributionFixed {
+		mi.declaredcontribution = max(mi.intendedContribution, mi.AoAExpectedContribution)
+	} else {
+		if mi.intendedContribution > 0 {
+			mi.declaredcontribution = mi.intendedContribution
+		} else {
+			mi.declaredcontribution = rand.Intn(11) + 2
+		}
+	}
+	if mi.intendedContribution < mi.AoAExpectedContribution {
+		mi.haveIlied = true
+	}
+
+	return mi.intendedContribution
+}
+
+func (mi *MI_256_v1) GetActualContribution(instance common.IExtendedAgent) int {
+	if mi.HasTeam() {
+		mi.intendedContribution = mi.DecideContribution()
+		return mi.intendedContribution
+	} else {
+		if mi.VerboseLevel > 6 {
+		}
+		return 0
+	}
+}
+
+func (mi *MI_256_v1) GetStatedContribution(instance common.IExtendedAgent) int {
+	return mi.declaredcontribution
 }
 
 // Withdrawal Strategy
-func (mi *MI_256_v1) DecideWithdrawal() int {
+func (mi *MI_256_v1) DecideWithdrawal(upperbound int) int {
+	fmt.Print("deciding withdrawal")
+	mi.CalcAOAWithdrawal()
+	if mi.AoAExpectedWithdrawal == 0 {
+		mi.IntendedWithdrawal = 0
+		mi.declaredWithdrawal = 0
+		return 0
+	}
+
+	mi.IntendedWithdrawal = 0
+	Withdrawal_percentage := 0.0
+	// CurrentScore = mi.Score
+
+	mood_modifier := float64(1.0 / 100.0 * float64(mi.mood))
+	// we scale from 0-2*AoAWithdrawal
+	neutral_mean := float64(float64(mi.AoAExpectedWithdrawal) / float64((upperbound))) //normalize from 0-1
+	//we model evil and good with different standard deviations, with chaotic being high standard deviation,
+	lawful_evil_mean := neutral_mean * 9 / 8
+	neutral_evil_mean := neutral_mean/4 + neutral_mean
+	neutral_good_mean := neutral_mean * 7.0 / 8
+	lawful_good_mean := neutral_mean * 3.0 / 4
+	neutral_standard_deviation := float64(1.0 / 12)
+	lawful_standard_deviation := 1.0 / 16.0
+	chaotic_standard_deviation := 1.0 / 8
+	chaotic_good_standard_deviation := 2.0 / 8 * (1 - neutral_mean)
+	chaotic_evil_standard_deviation := 2.0 / 8 * neutral_mean
+	neutral_good_standard_deviation := 1.0 / 8 * (1 - neutral_mean)
+	neutral_evil_standard_deviation := 1.0 / 8 * neutral_mean
+	lawful_good_standard_deviation := 1.0 / 16 * (1 - neutral_mean)
+	lawful_evil_standard_deviation := 1.0 / 8 * neutral_mean
+
+	Apply_mood := func(Withdrawal_percentage float64) float64 {
+		if Withdrawal_percentage > float64(neutral_mean) {
+			return Withdrawal_percentage + mood_modifier
+		} else {
+			return Withdrawal_percentage - mood_modifier
+		}
+	}
+	if mi.evilness == 2 { // if agent has neutral evilness, use neutral mean
+		if mi.chaoticness == 1 { // if lawful neutral
+
+			Withdrawal_percentage = (rand.NormFloat64() * float64(lawful_standard_deviation)) + float64(neutral_mean)
+
+		} else if mi.chaoticness == 2 { // abs neutral
+			Withdrawal_percentage = (rand.NormFloat64() * float64(neutral_standard_deviation)) + float64(neutral_mean)
+
+		} else if mi.chaoticness == 3 { //chaotic neutral
+			Withdrawal_percentage = (rand.NormFloat64() * float64(chaotic_standard_deviation)) + float64(neutral_mean)
+
+		}
+
+	} else if mi.evilness == 1 { // if agent is good
+		if mi.chaoticness == 1 { // if lawful good
+
+			Withdrawal_percentage = (rand.NormFloat64() * float64(lawful_good_standard_deviation)) + float64(lawful_good_mean)
+
+		} else if mi.chaoticness == 2 { // neutral good
+			Withdrawal_percentage = (rand.NormFloat64() * float64(neutral_good_standard_deviation)) + float64(neutral_good_mean)
+
+		} else if mi.chaoticness == 3 { //chaotic good
+			Withdrawal_percentage = (rand.NormFloat64() * float64(chaotic_good_standard_deviation)) + float64(neutral_good_mean)
+
+		}
+
+	} else if mi.evilness == 3 { // if agent is evil
+		if mi.chaoticness == 1 { // if lawful evil
+
+			Withdrawal_percentage = (rand.NormFloat64() * float64(lawful_evil_standard_deviation)) + float64(lawful_evil_mean)
+
+		} else if mi.chaoticness == 2 { // neutral evil
+			Withdrawal_percentage = (rand.NormFloat64() * float64(neutral_evil_standard_deviation)) + float64(neutral_evil_mean)
+
+		} else if mi.chaoticness == 3 { //chaotic evil
+			Withdrawal_percentage = (rand.NormFloat64() * float64(chaotic_evil_standard_deviation)) + float64(neutral_evil_mean)
+
+		}
+	}
+	Withdrawal_percentage = Apply_mood(Withdrawal_percentage)
+	fmt.Println(mi.GetID(), " withdrawal percentage", Withdrawal_percentage)
+	mi.print_alignment()
+	mi.IntendedWithdrawal = max(int(math.Round(float64(Withdrawal_percentage)*float64(upperbound))), 0)
+
+	// how much to declare:
+	// if you withdrawed more, there is no point to lie ( if audition checks against the expected )
+	if mi.isAoAWithdrawalFixed {
+		mi.declaredWithdrawal = min(mi.IntendedWithdrawal, mi.AoAExpectedWithdrawal)
+	} else {
+		mi.declaredWithdrawal = mi.IntendedWithdrawal
+	}
+	if mi.IntendedWithdrawal > mi.AoAExpectedContribution {
+		mi.haveIlied = true
+	}
+
 	// TODO: implement contribution strategy
-	return 1
+	return mi.IntendedWithdrawal
+}
+
+func (mi *MI_256_v1) GetActualWithdrawal(instance common.IExtendedAgent) int {
+	// first check if the agent has a team
+	if !mi.HasTeam() {
+		return 0
+	}
+	commonPool := mi.Server.GetTeam(mi.GetID()).GetCommonPool()
+	mi.AoAExpectedWithdrawal = mi.CalcAOAWithdrawal()
+	if mi.Score < mi.lastThreshold+5 {
+		mi.IntendedWithdrawal = mi.DecideWithdrawal((commonPool))
+	} else {
+		mi.IntendedWithdrawal = mi.DecideWithdrawal((mi.AoAExpectedWithdrawal * 2))
+	}
+	// commonPool := mi.Server.GetTeam(mi.GetID()).GetCommonPool()
+	// withdrawal := mi.Server.GetTeam(mi.GetID()).TeamAoA.GetExpectedWithdrawal(mi.GetID(), mi.GetTrueScore(), commonPool)
+	// if commonPool < withdrawal {
+	// 	withdrawal = commonPool
+	// }
+
+	return mi.IntendedWithdrawal
+}
+
+func (mi *MI_256_v1) GetStatedWithdrawal(instance common.IExtendedAgent) int {
+	return mi.declaredWithdrawal
 }
 
 // Audit Strategy
-func (mi *MI_256_v1) DecideAudit() bool {
-	// TODO: implement audit strategy
-	return true
-}
+func (mi *MI_256_v1) BuildVotemap(IsHarmfulIntent bool) map[uuid.UUID]float64 {
+	// you decide who to audit based on your alignment, if there is a cheat happened, and your affinity of other agents, and the net affinity change this round
+	// alignment calculates the likelyhood of you initiating an audit
+	// cheat greatly modifies the likelyhood, if there is cheating detected, then there will be a greater chance of auditing
+	// affinity factors in the suspision,  if someone is declaring large contributions when there is a cheat, taking small sums when there are loads missing from the pool
+	mood_modifier := float64(1.0 / 100.0 * float64(mi.mood))
+	Apply_mood := func(audit_percentage, neutral_mean float64) float64 {
+		if audit_percentage > float64(neutral_mean) {
+			return audit_percentage + mood_modifier
+		} else {
+			return audit_percentage - mood_modifier
+		}
+	}
+	auditmap := make(map[uuid.UUID]float64)
 
-// Punishment Strategy
-func (mi *MI_256_v1) DecidePunishment() int {
-	// TODO: implement punishment strategy
-	return 1
-}
+	var abs_neutral_mean, neutral_evil_mean, neutral_good_mean, lawful_good_mean, lawful_evil_mean, lawful_neutral_mean, chaotic_neutral_mean, chaotic_evil_mean, chaotic_good_mean float64
+	var chaotic_neutral_standard_deviation, chaotic_good_standard_deviation, chaotic_evil_standard_deviation, neutral_good_standard_deviation, neutral_evil_standard_deviation, abs_neutral_standard_deviation, lawful_good_standard_deviation, lawful_evil_standard_deviation, lawful_neutral_standard_deviation float64
 
-// Need to do something about agents own ID in here
-func (mi *MI_256_v1) Team4_GetRankUpVote() map[uuid.UUID]int {
-	log.Printf("Called overriden GetRankUpVote()")
-	agentsInTeam := mi.Server.GetAgentsInTeam(mi.TeamID)
-	rankUpVote := make(map[uuid.UUID]int)
+	if IsHarmfulIntent {
 
-	for _, agentId := range agentsInTeam {
-		rankUpVote[agentId] = rand.Intn(2)
+		if !(mi.isThereCheatWithdrawal || mi.isThereCheatContribution) { // when no cheating happens
+
+			//we model evil and good with different standard deviations, with chaotic being high standard deviation,
+			abs_neutral_mean = 0.1
+			neutral_evil_mean = 0.15
+			neutral_good_mean = 0.05
+
+			lawful_good_mean = 0.05
+			lawful_evil_mean = 0.1
+			lawful_neutral_mean = 0.075
+
+			chaotic_neutral_mean = 0.15
+			chaotic_evil_mean = 0.2
+			chaotic_good_mean = 0.1
+
+			chaotic_neutral_standard_deviation = 0.07
+			chaotic_good_standard_deviation = 0.05
+			chaotic_evil_standard_deviation = 0.1
+
+			neutral_good_standard_deviation = 0.05
+			neutral_evil_standard_deviation = 0.05
+			abs_neutral_standard_deviation = 0.05
+
+			lawful_good_standard_deviation = 0.025
+			lawful_evil_standard_deviation = 0.025
+			lawful_neutral_standard_deviation = 0.025
+
+		} else { // when there is a cheat
+			abs_neutral_mean = 0.5
+			neutral_evil_mean = 0.75
+			neutral_good_mean = 0.25
+
+			lawful_good_mean = 0.1
+			lawful_evil_mean = 0.6
+			lawful_neutral_mean = 0.5
+
+			chaotic_neutral_mean = 0.5
+			chaotic_evil_mean = 0.85
+			chaotic_good_mean = 0.25
+
+			chaotic_neutral_standard_deviation = 0.2
+			chaotic_good_standard_deviation = 0.2
+			chaotic_evil_standard_deviation = 0.15
+
+			neutral_good_standard_deviation = 0.15
+			neutral_evil_standard_deviation = 0.15
+			abs_neutral_standard_deviation = 0.15
+
+			lawful_good_standard_deviation = 0.1
+			lawful_evil_standard_deviation = 0.1
+			lawful_neutral_standard_deviation = 0.1
+
+		}
+	} else {
+		// if this vote is to help them rank up, get more resource and etc.
+		if !(mi.isThereCheatWithdrawal || mi.isThereCheatContribution) { // when no cheating happens
+
+			//we model evil and good with different standard deviations, with chaotic being high standard deviation,
+			abs_neutral_mean = 0.4
+			neutral_evil_mean = 0.15
+			neutral_good_mean = 0.4
+
+			lawful_good_mean = 0.8
+			lawful_evil_mean = 0.2
+			lawful_neutral_mean = 0.4
+
+			chaotic_neutral_mean = 0.4
+			chaotic_evil_mean = 0.15
+			chaotic_good_mean = 0.8
+
+			chaotic_neutral_standard_deviation = 0.2
+			chaotic_good_standard_deviation = 0.2
+			chaotic_evil_standard_deviation = 0.2
+
+			neutral_good_standard_deviation = 0.1
+			neutral_evil_standard_deviation = 0.1
+			abs_neutral_standard_deviation = 0.1
+
+			lawful_good_standard_deviation = 0.05
+			lawful_evil_standard_deviation = 0.05
+			lawful_neutral_standard_deviation = 0.05
+
+		} else { // when there is a cheat
+			abs_neutral_mean = 0.25
+			neutral_evil_mean = 0.1
+			neutral_good_mean = 0.4
+
+			lawful_good_mean = 0.5
+			lawful_evil_mean = 0.1
+			lawful_neutral_mean = 0.25
+
+			chaotic_neutral_mean = 0.25
+			chaotic_evil_mean = 0.1
+			chaotic_good_mean = 0.4
+
+			chaotic_neutral_standard_deviation = 0.2
+			chaotic_good_standard_deviation = 0.2
+			chaotic_evil_standard_deviation = 0.2
+
+			neutral_good_standard_deviation = 0.1
+			neutral_evil_standard_deviation = 0.1
+			abs_neutral_standard_deviation = 0.1
+
+			lawful_good_standard_deviation = 0.05
+			lawful_evil_standard_deviation = 0.05
+			lawful_neutral_standard_deviation = 0.05
+
+		}
 	}
 
-	log.Println(rankUpVote)
-	return rankUpVote
-}
+	for _, agent := range mi.Server.GetTeam(mi.GetID()).Agents {
+		audit_percentage := 0.0
 
-func (mi *MI_256_v1) Team4_GetConfession() bool {
-	return true
-}
+		// we need to genereate a probability for each agent
+		if mi.evilness == 2 { // if agent has neutral evilness, use neutral mean
+			if mi.chaoticness == 1 { // if lawful neutral
 
-func (mi *MI_256_v1) Team4_GetProposedWithdrawalVote() map[uuid.UUID]int {
-	log.Printf("Called overriden GetProposedWithdrawalVote()")
-	agentsInTeam := mi.Server.GetAgentsInTeam(mi.TeamID)
-	proposedWithdrawals := make(map[uuid.UUID]int)
+				audit_percentage = (rand.NormFloat64() * float64(lawful_neutral_standard_deviation)) + float64(lawful_neutral_mean)
 
-	for _, agentId := range agentsInTeam {
-		proposedWithdrawals[agentId] = rand.Intn(2)
+			} else if mi.chaoticness == 2 { // abs neutral
+				audit_percentage = (rand.NormFloat64() * float64(abs_neutral_standard_deviation)) + float64(abs_neutral_mean)
+
+			} else if mi.chaoticness == 3 { //chaotic neutral
+				audit_percentage = (rand.NormFloat64() * float64(chaotic_neutral_standard_deviation)) + float64(chaotic_neutral_mean)
+
+			}
+
+		} else if mi.evilness == 1 { // if agent is good
+			if mi.chaoticness == 1 { // if lawful good
+
+				audit_percentage = (rand.NormFloat64() * float64(lawful_good_standard_deviation)) + float64(lawful_good_mean)
+
+			} else if mi.chaoticness == 2 { // neutral good
+				audit_percentage = (rand.NormFloat64() * float64(neutral_good_standard_deviation)) + float64(neutral_good_mean)
+
+			} else if mi.chaoticness == 3 { //chaotic good
+				audit_percentage = (rand.NormFloat64() * float64(chaotic_good_standard_deviation)) + float64(chaotic_good_mean)
+
+			}
+
+		} else if mi.evilness == 3 { // if agent is evil
+			if mi.chaoticness == 1 { // if lawful evil
+
+				audit_percentage = (rand.NormFloat64() * float64(lawful_evil_standard_deviation)) + float64(lawful_evil_mean)
+
+			} else if mi.chaoticness == 2 { // neutral evil
+				audit_percentage = (rand.NormFloat64() * float64(neutral_evil_standard_deviation)) + float64(neutral_evil_mean)
+
+			} else if mi.chaoticness == 3 { //chaotic evil
+				audit_percentage = (rand.NormFloat64() * float64(chaotic_evil_standard_deviation)) + float64(chaotic_evil_mean)
+
+			}
+		}
+		// we apply affinity, it will shift the mean(just the percentage) based on the affinity of that agnet
+		affinity_modifier := 0.03
+		ignore_thresh := 10
+		if mi.affinity[agent] > ignore_thresh {
+			audit_percentage -= math.Sqrt(float64(mi.affinity[agent]-10)) * affinity_modifier
+		} else if mi.affinity[agent] < -ignore_thresh {
+			audit_percentage -= math.Sqrt(float64(mi.affinity[agent]+10)) * affinity_modifier
+		}
+
+		Apply_mood(audit_percentage, abs_neutral_mean)
+		auditmap[agent] = audit_percentage
+
 	}
 
-	log.Println(proposedWithdrawals)
-	return proposedWithdrawals
+	return auditmap
+
 }
 
 func (mi *MI_256_v1) GetWithdrawalAuditVote() common.Vote {
-	log.Printf("Called overriden GetWithdrawalAuditVote()")
+	// fmt.Println("audit starts")
+	/*vote happens at many occasions:
 
-	// Get the agents in the team
-	agentsInTeam := mi.Server.GetAgentsInTeam(mi.TeamID)
-
-	// Check if the team has any agents
-	if len(agentsInTeam) == 0 {
-		return common.CreateVote(0, mi.GetID(), uuid.Nil)
+	when approving to rank up
+	when approving withdrawal
+	voting for a leader(maybe)s
+	voting for a AoA
+	voting for audition
+	*/
+	// TODO: implement vote strategy
+	votemap := mi.BuildVotemap(true)
+	var max_agent uuid.UUID
+	max_audit_perentage := 0.0
+	for agent, audit_percentage := range votemap {
+		if audit_percentage > float64(max_audit_perentage) {
+			max_agent = agent
+			max_audit_perentage = audit_percentage
+		}
 	}
+	var vote common.Vote
+	random := rand.Float64()
+	if random <= max_audit_perentage {
+		vote = common.CreateVote(1, mi.GetID(), max_agent)
 
-	firstAgentID := agentsInTeam[0]
+	} else if random >= max_audit_perentage+(1-max_audit_perentage)/2 {
+		vote = common.CreateVote(-1, mi.GetID(), max_agent)
+	} else {
+		// if in this range, abstain
+		vote = common.CreateVote(0, mi.GetID(), max_agent)
+	}
+	fmt.Println(mi.GetID(), " audit vote", vote)
+	return vote
 
-	return common.CreateVote(1, mi.GetID(), firstAgentID)
 }
 
-func (mi *MI_256_v1) Team4_GetPunishmentVoteMap() map[int]int {
-	punishmentVoteMap := make(map[int]int)
+func (mi *MI_256_v1) Team4_GetRankUpVote() map[uuid.UUID]int {
+	// log.Printf("Called overriden GetRankUpVote()")
+	votePercentmap := mi.BuildVotemap(false)
+	votemap := make(map[uuid.UUID]int)
+	for agent, percentage := range votePercentmap {
+		random := rand.Float64()
+		if random <= percentage {
+			votemap[agent] = 1
+		} else if random >= percentage+(1-percentage)/2 {
+			votemap[agent] = -1
+		} else {
+			votemap[agent] = 0
+			// if in this range, abstain
 
-	for punishment := 0; punishment <= 4; punishment++ {
-		punishmentVoteMap[punishment] = rand.Intn(5)
+		}
 	}
+	return votemap
+}
 
-	return punishmentVoteMap
+func (mi *MI_256_v1) Team4_GetConfession() bool {
+	chance := rand.Intn(2)
+	if chance != 0 {
+		return true
+	}
+	return false
+}
+
+func (mi *MI_256_v1) Team4_GetProposedWithdrawalVote() map[uuid.UUID]int {
+	// log.Printf("Called overriden GetProposedWithdrawalVote()")
+	votePercentmap := mi.BuildVotemap(false)
+	votemap := make(map[uuid.UUID]int)
+	for agent, percentage := range votePercentmap {
+		random := rand.Float64()
+		if random <= percentage {
+			votemap[agent] = 1
+		} else if random >= percentage+(1-percentage)/2 {
+			votemap[agent] = -1
+		} else {
+			votemap[agent] = 0
+			// if in this range, abstain
+
+		}
+	}
+	return votemap
 }
 
 // ----------------------- State Helpers -----------------------
 // TODO: add helper functions for managing / using internal states
+
+//get common pool resource
+
+// mi.Server.GetTeam(mi.GetID()).GetCommonPool()
+
+// //get ids of people in my team
+// mi.Server.GetTeam(mi.GetID()).Agents
+
+// //get the voting status (to implement)
+
+// mi.Server.GetTeam(mi.GetID()).
+
+// ---------------------------------------------------------------
+func (mi *MI_256_v1) RandomizeCharacter() {
+	mi.chaoticness = rand.Intn(3) + 1
+
+	mi.evilness = rand.Intn(3) + 1
+	mi.haveIlied = false
+	mi.Initialize_opninions()
+	mi.AoARanking = []int{4, 1, 2, 3, 4, 5}
+	mi.SetAoARanking(mi.AoARanking)
+}
+
+// ----------- functions that update character opinions ---------------------------------
+
+func (mi *MI_256_v1) Initialize_opninions() {
+	mi.affinity = make(map[uuid.UUID]int)
+	for _, agent := range mi.Server.UpdateAndGetAgentExposedInfo() {
+		mi.affinity[agent.AgentUUID] = 0
+		mi.affinityChange[agent.AgentUUID] = 0
+	}
+	// needs to change
+	mi.mood = 0
+
+}
+
+func (mi *MI_256_v1) Team4_UpdateStateStartTurn() {
+	// overwrite if your agent need to update internal state at this stage.
+
+	// this function updates the agent states every start of turn, refreshing states if needed
+	fmt.Println(mi.GetID(), " mood this turn", mi.mood)
+	mi.UpdateMoodTurnStart()
+	mi.haveIlied = false
+	for key := range mi.affinityChange {
+		mi.affinityChange[key] = 0
+	}
+	mi.isThereCheatContribution = false
+	mi.isThereCheatWithdrawal = false
+	if mi.Score < mi.lastTurnScore {
+		mi.lastThreshold = mi.lastTurnScore - mi.Score
+	}
+
+}
+
+/*
+Mood decides wether the agent want to be more active
+Mood needs to be updated at the following timepoints:
+
+1. At the start of turn, where a random Urge is generated
+2. Dice rolls, wether if you have gone bust or not
+3. Comparing the expected Score of every agent after round end to you
+4. If you get audited,
+
+*/
+
+func (mi *MI_256_v1) UpdateMoodTurnStart() {
+	//generate random float from -1 to 1 and multiply by chaoticness
+
+	randomUrge := (rand.Float64()*2 - 1) * float64(mi.chaoticness)
+	randomUrge = math.Round(randomUrge)
+	mi.mood += int(randomUrge)
+}
+func (mi *MI_256_v1) UpdateMoodAfterRoll() {
+
+	bustMoodModifier := 1
+	// if the roll has gone bust
+	if mi.LastScore == 0 {
+		mi.mood += bustMoodModifier * (mi.chaoticness - 2)
+
+	}
+}
+
+func (mi *MI_256_v1) UpdateMoodAfterRoundEnd() {
+	numAgent := 0
+	contributedSum, withdrawalSum := 0, 0
+	for _, agent := range mi.Server.GetTeam(mi.GetID()).Agents {
+		contributedSum += mi.teamAgentsDeclaredContribution[agent]
+		withdrawalSum += mi.teamAgentsDeclaredWithdraw[agent]
+		numAgent += 1
+
+	}
+	averageNetgain := float64((withdrawalSum - contributedSum) / numAgent)
+	personalNetgain := mi.IntendedWithdrawal - mi.intendedContribution
+
+	//comparing the agent's performance to your own performance
+	if float64(personalNetgain) < (averageNetgain) {
+		teamPerformanceModifier := 3
+		// change if you are not doing very well
+		mi.mood += teamPerformanceModifier * (mi.chaoticness - 2)
+	} else if float64(personalNetgain) > (averageNetgain) {
+		teamPerformanceModifier := 1
+		//else you feel confident about your current mood
+		mi.mood += teamPerformanceModifier * (mi.chaoticness)
+
+	}
+	// if lying and not caught, be more adventurous, else no.
+	lyingModifier := 1
+	if mi.haveIlied && mi.IcaughtLying {
+		// mood decreases
+		mi.mood -= lyingModifier * mi.chaoticness
+	} else if mi.haveIlied && !mi.IcaughtLying {
+		mi.mood += lyingModifier * mi.chaoticness
+	}
+	// you calculate everyone's declared net gain,
+
+}
+func (mi *MI_256_v1) UpdateMoodAfterAuditionEnd() {
+	// if you get audited and has been caught lying, then you probably want to be more greedy to survive
+	if mi.IcaughtLying {
+		mi.mood = 3 * mi.chaoticness
+	}
+
+}
+
+/*
+Affinity decides the likelyhood of our Agent will support other agent's decisions
+
+Affinity should be updated when:
+1. They declared their contributions and Withdrawals. The Amount
+2. When they voted to audit you
+3. When someone has failed an audit
+4. When agents propose their Ideologies.
+*/
+func (mi *MI_256_v1) UpdateAffinityAoAProposal() {
+	// need to see all of the AoA in detail
+}
+
+func (mi *MI_256_v1) UpdateAffinityAfterContribute() {
+	//this function is called
+	// we need to value if the declared contribution is fair, we do not know what everyone rolled, we only know their declared contribution against expected
+	// apart from the fairness, there is also the satisfaction. Good people would tend to "understand" if they are not contributing as much, while evil people would want people to donate more
+	// and of course, both sides would love people that donates more, more for good people, less for evil people because their is a cheat probability
+
+	// contructing a socially fair structure:
+	// simple, meeting the AoA Expected Contribution==fair
+
+	// if we do not know their expected contributions however,  we could measure the average of all the declared contributions, and use that as agent expected.
+
+	sum := 0
+	numAgent := 0
+	for _, agent := range mi.Server.GetTeam(mi.GetID()).Agents {
+		sum += mi.teamAgentsDeclaredContribution[agent]
+		numAgent += 1
+
+	}
+	agentExpected := sum / numAgent
+	for _, agent := range mi.Server.GetTeam(mi.GetID()).Agents {
+
+		if mi.isAoAContributionFixed {
+			agentExpected = mi.teamAgentsDeclaredContribution[agent]
+		}
+		affinityChange := 0.0
+		agentDeclared := mi.teamAgentsDeclaredContribution[agent]
+		// fairness, if they contributed more or less than expected, less take note, more don't do anything
+		fairnessThresh := 0.5
+		if agentDeclared < agentExpected {
+			affinityChange -= float64(agentExpected-agentDeclared) * (fairnessThresh)
+		}
+
+		if !mi.isThereCheatContribution {
+
+			// satisfaction if there are no cheats, so we value people highly
+			satisfactionThresh := 0.5
+			if agentDeclared < agentExpected {
+				amount_less := float64(agentExpected - agentDeclared)
+				affinityChange -= (satisfactionThresh) * float64(mi.evilness-1) * math.Sqrt(amount_less)
+			} else {
+				amount_more := -float64(agentExpected - agentDeclared)
+				affinityChange += (satisfactionThresh) * float64(3-(mi.evilness-1)) * math.Sqrt(amount_more)
+			}
+		} else { // if there are cheats happening, we would like to be more spectical
+			// good people would still think they are good, but with less modifier, neutral people hold thought, and evil would decrease if they say contributed more (suspision)
+			satisfactionThresh := 0.5
+			if agentDeclared < agentExpected {
+				//if you contribute less than expected, no change
+				amount_less := float64(agentExpected - agentDeclared)
+				affinityChange -= (satisfactionThresh) * float64(mi.evilness-1) * math.Sqrt(amount_less)
+			} else {
+				// if you donate more or equal to, we suspect you
+				amount_more := -float64(agentExpected - agentDeclared)
+				affinityChange += (satisfactionThresh) * float64(-(mi.evilness - 2)) * math.Sqrt(amount_more)
+			}
+		}
+
+		mi.affinity[agent] += int(affinityChange)
+
+		mi.affinityChange[agent] += int(affinityChange)
+
+	}
+
+}
+func (mi *MI_256_v1) UpdateAffinityAfterWithdraw() {
+	//similar to contribution, there withdrawing same amount is fair, and satisfaction comes into play
+	// if there is no set distribution, we would assume the avarage amount in the pot would be a fair number
+	common_pool := mi.Server.GetTeam(mi.GetID()).GetCommonPool()
+	agentExpected := int(common_pool / (len(mi.Server.GetTeam(mi.GetID()).Agents) + 1))
+
+	for _, agent := range mi.Server.GetTeam(mi.GetID()).Agents {
+		if mi.isAoAWithdrawalFixed {
+			agentExpected = mi.teamAgentsExpectedWithdraw[agent]
+		}
+
+		agentDeclared := mi.teamAgentsDeclaredWithdraw[agent]
+		affinityChange := 0.0
+		// fairness, if they withdrawed more or less than expected, less take note, more don't do anything
+		fairnessThresh := 0.5
+		if agentDeclared > agentExpected {
+			affinityChange += float64(agentExpected-agentDeclared) * (fairnessThresh)
+		}
+		// satisfaction ( not too important as if they miss they will cheat anyways so you can't tell)
+
+		if !mi.isThereCheatWithdrawal {
+
+			satisfactionThresh := 0.5
+			if agentDeclared < agentExpected {
+				amount_less := float64(agentExpected - agentDeclared)
+				affinityChange += (satisfactionThresh) * float64(mi.evilness-1) * math.Sqrt(amount_less)
+			} else {
+				amount_more := -float64(agentExpected - agentDeclared)
+				affinityChange -= (satisfactionThresh) * float64(3-(mi.evilness-1)) * math.Sqrt(amount_more)
+			}
+		} else {
+			// if there are cheat, then we would be more critical on whoever says they took equal or less
+			satisfactionThresh := 0.5
+			if agentDeclared < agentExpected {
+				amount_less := float64(agentExpected - agentDeclared)
+				affinityChange += (satisfactionThresh) * float64(-(mi.evilness - 2)) * math.Sqrt(amount_less)
+			} else {
+				amount_more := -float64(agentExpected - agentDeclared)
+				affinityChange -= (satisfactionThresh) * float64(3-(mi.evilness-1)) * math.Sqrt(amount_more)
+			}
+
+		}
+		mi.affinity[agent] += int(affinityChange)
+		mi.affinityChange[agent] += int(affinityChange)
+
+	}
+
+}
+func (mi *MI_256_v1) UpdateAffinityAfterVote() {
+	// whenever a vote happens, if the vote is targeting you, someone you really dislike, someone you really like, you would change affinity based on people's votes.
+
+	if mi.lastAuditTarget == mi.GetID() { // if the target agent is yourself:
+		//then you would really not like the guy that targeted you, and not like whoever voted yes to vote you out
+		for _, agent := range mi.Server.GetTeam(mi.GetID()).Agents {
+			affinityChange := 0
+			if mi.lastAuditStarter == agent {
+				affinityChange -= 5
+			}
+			voteAgainstAffinityChange := 3
+			voteForAffinityChange := 1
+			if mi.lastVotes[agent] {
+				//affninity changes based on the chaoticness, the more chaotic, the more you cannot stand the person
+				affinityChange -= voteAgainstAffinityChange * mi.chaoticness
+			} else {
+				affinityChange += voteForAffinityChange * mi.chaoticness
+			}
+			mi.affinity[agent] += affinityChange
+		}
+
+	} else if mi.affinity[mi.lastAuditTarget] <= -10 { // if the vote is against someone you really dislike, you gain little change for people agreeing to it, but dislike people who disagree with it
+		for _, agent := range mi.Server.GetTeam(mi.GetID()).Agents {
+			affinityChange := 0
+			if mi.lastAuditStarter == agent {
+
+				affinityChange += 2
+			}
+
+			voteAgainstAffinityChange := 2
+			voteForAffinityChange := 1
+			if mi.lastVotes[agent] {
+				//affninity changes based on the chaoticness, the more chaotic, the more you cannot stand the person
+				affinityChange += voteForAffinityChange * mi.chaoticness
+			} else {
+				affinityChange -= voteAgainstAffinityChange * mi.chaoticness
+			}
+			mi.affinity[agent] += affinityChange
+		}
+	} else if mi.affinity[mi.lastAuditTarget] <= -10 { // if the vote is against someone you really like, you gain little dislike for people agreeing to it, but like people who disagree with it
+		for _, agent := range mi.Server.GetTeam(mi.GetID()).Agents {
+			affinityChange := 0
+			if mi.lastAuditStarter == agent {
+				if mi.isThereCheatWithdrawal || mi.isThereCheatContribution {
+					affinityChange -= 2
+				} else {
+					affinityChange -= 3 // you would get more mad if there seems to be no cheating this round
+				}
+
+			}
+			voteAgainstAffinityChange := 0
+			voteForAffinityChange := 0
+			if mi.isThereCheatWithdrawal || mi.isThereCheatContribution {
+				voteAgainstAffinityChange = 1
+				voteForAffinityChange = 2
+			} else {
+				voteAgainstAffinityChange = 1
+				voteForAffinityChange = 3
+			}
+
+			if mi.lastVotes[agent] {
+				//affninity changes based on the chaoticness, the more chaotic, the more you cannot stand the person
+				affinityChange -= voteForAffinityChange * mi.chaoticness
+			} else {
+				affinityChange += voteAgainstAffinityChange * mi.chaoticness
+			}
+			mi.affinity[agent] += affinityChange
+		}
+	}
+
+}
+
+func (mi *MI_256_v1) UpdateAffinityAfterAudit() {
+	//if someone fails or succeeds an audit, then you would gain impression of them
+	affinityChange := 0
+	if mi.lastAuditResult {
+		// if the audit is successful, then you would like the person less
+		affinityChange = -1
+	} else {
+		// if the audit is unsuccessful, then you would like the person more
+		affinityChange = 1
+	}
+	mi.affinity[mi.lastAuditTarget] += 2 * affinityChange * mi.chaoticness
+	mi.affinity[mi.lastAuditStarter] -= affinityChange * mi.chaoticness
+}
+
+// ----------------------- Helper Functions -----------------------
+func GetAgentTeamAoA(mi *MI_256_v1) common.IArticlesOfAssociation {
+	return mi.Server.GetTeam(mi.GetID()).TeamAoA
+}
+
+func (mi *MI_256_v1) Team4_ProposeWithdrawal() int {
+	// first check if the agent has a team
+	if !mi.HasTeam() {
+		return 0
+	}
+	mi.DecideWithdrawal(mi.Server.GetTeam(mi.GetID()).GetCommonPool())
+	return mi.IntendedWithdrawal
+}
+func (mi *MI_256_v1) Team4_GetPunishmentVoteMap() map[int]int {
+	punishmentVoteMap := make(map[int]int)
+
+	for punishment := 0; punishment <= 4; punishment++ {
+		punishmentVoteMap[punishment] = min(4, rand.Intn(5)+max(mi.evilness-2, 0))
+	}
+
+	return punishmentVoteMap
+}

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	serv := &envServer.EnvironmentServer{
 		// note: the zero turn is used for team forming
 		BaseServer: baseServer.CreateBaseServer[common.IExtendedAgent](
-			2,                   //  iterations
+			3,                   //  iterations
 			100,                 //  turns per iteration
 			50*time.Millisecond, //  max duration
 			10),                 //  message bandwidth
@@ -98,6 +98,6 @@ func main() {
 	serv.LogTeamStatus()
 
 	// record data
-	serv.DataRecorder.GamePlaybackSummary()
+	// serv.DataRecorder.GamePlaybackSummary()
 	gameRecorder.ExportToCSV(serv.DataRecorder, "visualization_output/csv_data")
 }

--- a/visualization_dashboard.py
+++ b/visualization_dashboard.py
@@ -60,32 +60,6 @@ app.layout = html.Div([
     html.H1("Agent Performance Dashboard"),
     
     html.Div([
-<<<<<<< Updated upstream
-        html.Div([
-            html.H3("Score Evolution Over Time"),
-            dcc.Graph(id='score-evolution'),
-        ], className='graph-container'),
-        
-        html.Div([
-            html.H3("Contribution vs Withdrawal"),
-            dcc.Graph(id='contribution-withdrawal'),
-        ], className='graph-container'),
-        
-        html.Div([
-            html.H3("Common Pool Evolution"),
-            dcc.Graph(id='common-pool'),
-        ], className='graph-container'),
-        
-        html.Div([
-            html.H3("Agent Status"),
-            dcc.Graph(id='agent-status'),
-        ], className='graph-container'),
-    ]),
-    
-    # Add filters
-    html.Div([
-=======
->>>>>>> Stashed changes
         html.H3("Filters"),
         dcc.Dropdown(
             id='iteration-filter',
@@ -355,8 +329,6 @@ def update_agent_status(iteration):
         
     return fig
 
-<<<<<<< Updated upstream
-=======
 # Add new callback for team-based score evolution
 @app.callback(
     Output('score-evolution-by-team', 'figure'),
@@ -590,7 +562,6 @@ def update_individual_net_contributions(iteration, n_intervals):
     
     return fig
 
->>>>>>> Stashed changes
 # Add some CSS styling
 app.index_string = '''
 <!DOCTYPE html>

--- a/visualization_dashboard.py
+++ b/visualization_dashboard.py
@@ -5,20 +5,43 @@ from dash.dependencies import Input, Output
 import plotly.express as px
 import plotly.graph_objects as go
 from datetime import datetime
+import hashlib
+import json
 
 # Add these constants at the top of the file for consistent plot styling
 PLOT_HEIGHT = 600  # Increased height
 PLOT_WIDTH = 1000   # Increased from 700 to 1000
 PLOT_MARGIN = dict(r=150)  # More space on the right for legends
 
+# Add these global variables after the PLOT constants
+last_data_hash = None
+cached_data = None
+
 # Move the data loading into a function
 def load_data():
+    global last_data_hash, cached_data
+    
     base_path = 'visualization_output/csv_data'
-    return {
+    current_data = {
         'agent_records': pd.read_csv(f'{base_path}/agent_records.csv'),
         'common_records': pd.read_csv(f'{base_path}/common_records.csv'),
         'team_records': pd.read_csv(f'{base_path}/team_records.csv')
     }
+    
+    # Create a hash of the current data
+    hash_string = ''
+    for df in current_data.values():
+        hash_string += df.to_json()
+    current_hash = hashlib.md5(hash_string.encode()).hexdigest()
+    
+    # If the hash matches, return cached data
+    if last_data_hash == current_hash and cached_data is not None:
+        return cached_data
+    
+    # Otherwise, update cache and return new data
+    last_data_hash = current_hash
+    cached_data = current_data
+    return current_data
 
 # Load initial data
 data = load_data()
@@ -31,12 +54,13 @@ app = dash.Dash(__name__)
 app.layout = html.Div([
     dcc.Interval(
         id='interval-component',
-        interval=5*1000,  # in milliseconds (5 seconds)
+        interval=5000*1000,  # in milliseconds (5 seconds)
         n_intervals=0
     ),
     html.H1("Agent Performance Dashboard"),
     
     html.Div([
+<<<<<<< Updated upstream
         html.Div([
             html.H3("Score Evolution Over Time"),
             dcc.Graph(id='score-evolution'),
@@ -60,6 +84,8 @@ app.layout = html.Div([
     
     # Add filters
     html.Div([
+=======
+>>>>>>> Stashed changes
         html.H3("Filters"),
         dcc.Dropdown(
             id='iteration-filter',
@@ -68,7 +94,29 @@ app.layout = html.Div([
             value=0,
             clearable=False
         ),
-    ], style={'width': '200px', 'margin': '20px'})
+    ], style={'width': '200px', 'margin': '20px'}),
+    
+    html.Div([
+        html.Div([
+            dcc.Graph(id='score-evolution'),
+        ], className='graph-container'),
+        
+        html.Div([
+            dcc.Graph(id='score-evolution-by-team'),
+        ], className='graph-container'),
+        
+        html.Div([
+            dcc.Graph(id='common-pool'),
+        ], className='graph-container'),
+        
+        html.Div([
+            dcc.Graph(id='agent-status'),
+        ], className='graph-container'),
+        
+        html.Div([
+            dcc.Graph(id='individual-net-contributions'),
+        ], className='graph-container'),
+    ]),
 ])
 
 # Callback for score evolution with threshold overlay
@@ -85,6 +133,8 @@ def update_score_evolution(iteration, n_intervals):
     
     fig = go.Figure()
     
+    # Get all unique TrueSomasTeamIDs for creating buttons
+    unique_teams = sorted(filtered_data['TrueSomasTeamID'].unique())
     
     # Group agents by their true team ID
     for team_id in filtered_data['TrueSomasTeamID'].unique():
@@ -113,7 +163,7 @@ def update_score_evolution(iteration, n_intervals):
                 fig.add_trace(go.Scatter(
                     x=plot_data['TurnNumber'],
                     y=plot_data['Score'],
-                    name=f'T{team_id}_{agent_info["TeamID"][:4]}_{agent_info["SpecialNote"]}_{agent_id[:8]}',
+                    name=f'T{team_id}_{agent_info["TeamID"][:4]}_{agent_id[:8]}',
                     mode='lines',
                     line=dict(color=team_color)
                 ))
@@ -149,10 +199,58 @@ def update_score_evolution(iteration, n_intervals):
             opacity=0.5
         )
     
+    # Add buttons for team visibility
+    updatemenus = [
+        dict(
+            type="dropdown",
+            direction="down",
+            x=-0.1,
+            y=1.2,
+            xanchor="left",
+            yanchor="top",
+            showactive=True,
+            bgcolor='rgb(238, 238, 238)',
+            bordercolor='rgb(200, 200, 200)',
+            borderwidth=1,
+            pad={"r": 10, "t": 10},
+            buttons=[
+                # Button to show all teams
+                dict(
+                    label="All Teams",
+                    method="update",
+                    args=[{"visible": [True] * len(fig.data)}]
+                ),
+            ] +
+            # Button for each team
+            [dict(
+                label=f"Team {team_id}",
+                method="update",
+                args=[{"visible": [
+                    # For each trace, handle special cases and team filtering
+                    True if not hasattr(trace, 'name') or trace.mode == 'text'  # Keep death markers
+                    else True if getattr(trace, 'name', None) == 'Threshold'  # Keep threshold line
+                    else True if getattr(trace, 'name', None) and trace.name.startswith(f'T{team_id}_')  # Check team
+                    else False
+                    for trace in fig.data
+                ]}]
+            ) for team_id in unique_teams],
+            active=0,
+            font={"size": 12}
+        )
+    ]
+    
+    # Update layout with buttons
     fig.update_layout(
-        title='Score Evolution Over Time with Threshold',
-        xaxis_title="Turn Number",
-        yaxis_title="Score",
+        title=dict(
+            text='Score Evolution Over Time - By True Team',
+            y=0.95,
+            x=0.5,
+            xanchor='center',
+            yanchor='top'
+        ),
+        margin=dict(t=150, r=150, b=50, l=50),
+        height=PLOT_HEIGHT,
+        width=PLOT_WIDTH,
         hovermode='x unified',
         showlegend=True,
         legend=dict(
@@ -162,68 +260,7 @@ def update_score_evolution(iteration, n_intervals):
             xanchor="left",
             x=1.05
         ),
-        height=PLOT_HEIGHT,
-        width=PLOT_WIDTH,
-        margin=PLOT_MARGIN
-    )
-    
-    return fig
-
-# Callback for contribution vs withdrawal
-@app.callback(
-    Output('contribution-withdrawal', 'figure'),
-    [Input('iteration-filter', 'value')]
-)
-def update_contribution_withdrawal(iteration):
-    filtered_data = agent_records[agent_records['IterationNumber'] == iteration]
-    
-    fig = go.Figure()
-    
-    # Group by team ID
-    for team_id in filtered_data['TrueSomasTeamID'].unique():
-        team_data = filtered_data[filtered_data['TrueSomasTeamID'] == team_id]
-        team_color = px.colors.qualitative.Set1[team_id % len(px.colors.qualitative.Set1)]
-        
-        # Calculate mean values per turn for this team
-        mean_data = team_data.groupby('TurnNumber').agg({
-            'Contribution': 'mean',
-            'Withdrawal': 'mean'
-        }).reset_index()
-        
-        fig.add_trace(go.Scatter(
-            x=mean_data['TurnNumber'],
-            y=mean_data['Contribution'],
-            name=f'Team {team_id} - Contribution',
-            mode='lines+markers',
-            line=dict(color=team_color),
-            marker=dict(symbol='circle')
-        ))
-        
-        fig.add_trace(go.Scatter(
-            x=mean_data['TurnNumber'],
-            y=mean_data['Withdrawal'],
-            name=f'Team {team_id} - Withdrawal',
-            mode='lines+markers',
-            line=dict(color=team_color, dash='dash'),
-            marker=dict(symbol='square')
-        ))
-    
-    fig.update_layout(
-        title='Average Contribution vs Withdrawal Over Time by Team',
-        xaxis_title="Turn Number",
-        yaxis_title="Value",
-        hovermode='x unified',
-        showlegend=True,
-        legend=dict(
-            groupclick="toggleitem",
-            yanchor="top",
-            y=0.99,
-            xanchor="left",
-            x=1.05
-        ),
-        height=PLOT_HEIGHT,
-        width=PLOT_WIDTH,
-        margin=PLOT_MARGIN
+        updatemenus=updatemenus
     )
     
     return fig
@@ -262,7 +299,7 @@ def update_common_pool(iteration):
         ),
         height=PLOT_HEIGHT,
         width=PLOT_WIDTH,
-        margin=PLOT_MARGIN
+        margin=dict(t=150, r=150, b=50, l=50)
     )
     
     return fig
@@ -313,11 +350,247 @@ def update_agent_status(iteration):
         ),
         height=PLOT_HEIGHT,
         width=PLOT_WIDTH,
-        margin=PLOT_MARGIN
+        margin=dict(t=150, r=150, b=50, l=50)
     )
         
     return fig
 
+<<<<<<< Updated upstream
+=======
+# Add new callback for team-based score evolution
+@app.callback(
+    Output('score-evolution-by-team', 'figure'),
+    [Input('iteration-filter', 'value'),
+     Input('interval-component', 'n_intervals')]
+)
+def update_score_evolution_by_team(iteration, n_intervals):
+    # Reload data each time
+    data = load_data()
+    filtered_data = data['agent_records'][data['agent_records']['IterationNumber'] == iteration]
+    threshold_data = data['common_records'][data['common_records']['IterationNumber'] == iteration]
+    
+    fig = go.Figure()
+    
+    # Get all unique TeamIDs for creating buttons
+    unique_teams = sorted(filtered_data['TeamID'].unique())
+    
+    # Group agents by their TeamID instead of TrueSomasTeamID
+    for idx, (team_id, team_data) in enumerate(filtered_data.groupby('TeamID')):
+        # Create a consistent color for this team
+        team_color = px.colors.qualitative.Set1[idx % len(px.colors.qualitative.Set1)]
+        
+        # Plot each agent in the team
+        for agent_id in team_data['AgentID'].unique():
+            agent_data = team_data[team_data['AgentID'] == agent_id]
+            
+            # Find where agent dies (if it does)
+            death_point = None
+            if any(~agent_data['IsAlive']):
+                death_data = agent_data[~agent_data['IsAlive']]
+                if not death_data.empty:
+                    death_point = death_data.iloc[0]
+            
+            # Plot including the death point
+            if death_point is not None:
+                # Include all data up to and including death point
+                plot_data = agent_data[agent_data['TurnNumber'] <= death_point['TurnNumber']]
+            else:
+                plot_data = agent_data
+            
+            if not plot_data.empty:
+                # Get the first row of agent_data to extract consistent metadata
+                agent_info = agent_data.iloc[0]
+                fig.add_trace(go.Scatter(
+                    x=plot_data['TurnNumber'],
+                    y=plot_data['Score'],
+                    name=f'T{agent_info["TrueSomasTeamID"]}_{team_id[:4]}_{agent_id[:8]}',
+                    mode='lines',
+                    line=dict(color=team_color)
+                ))
+            
+            # Add skull emoji at death point if agent dies
+            if death_point is not None:
+                fig.add_trace(go.Scatter(
+                    x=[death_point['TurnNumber']],
+                    y=[death_point['Score']],
+                    mode='text',
+                    text=['💀'],
+                    textfont=dict(size=20),
+                    showlegend=False,
+                    hoverinfo='skip'
+                ))
+    
+    # Add threshold line
+    fig.add_trace(go.Scatter(
+        x=threshold_data['TurnNumber'] + 1,  # Add 1 to shift right
+        y=threshold_data['Threshold'],
+        name='Threshold',
+        mode='lines',
+        line=dict(color='red', dash='dash'),
+    ))
+    
+    # Add vertical lines for threshold application turns
+    threshold_turns = threshold_data[threshold_data['ThresholdAppliedInTurn'] == True]['TurnNumber']
+    for turn in threshold_turns:
+        fig.add_vline(
+            x=turn,
+            line_dash="dash",
+            line_color="red",
+            opacity=0.5
+        )
+    
+    # Add buttons for team visibility
+    updatemenus = [
+        dict(
+            type="dropdown",
+            direction="down",
+            x=-0.1,
+            y=1.2,
+            xanchor="left",
+            yanchor="top",
+            showactive=True,
+            bgcolor='rgb(238, 238, 238)',
+            bordercolor='rgb(200, 200, 200)',
+            borderwidth=1,
+            pad={"r": 10, "t": 10},
+            buttons=[
+                # Button to show all teams
+                dict(
+                    label="All Teams",
+                    method="update",
+                    args=[{"visible": [True] * len(fig.data)}]
+                ),
+            ] +
+            # Button for each team
+            [dict(
+                label=f"Team {team_id[:4]}",
+                method="update",
+                args=[{"visible": [
+                    # For each trace, handle special cases and team filtering
+                    True if not hasattr(trace, 'name') or trace.mode == 'text'  # Keep death markers
+                    else True if getattr(trace, 'name', None) == 'Threshold'  # Keep threshold line
+                    else True if getattr(trace, 'name', None) and team_id[:4] in trace.name  # Check team
+                    else False
+                    for trace in fig.data
+                ]}]
+            ) for team_id in unique_teams],
+            active=0,
+            font={"size": 12}
+        )
+    ]
+    
+    # Update layout with buttons
+    fig.update_layout(
+        title=dict(
+            text='Score Evolution Over Time - By Team',
+            y=0.95,
+            x=0.5,
+            xanchor='center',
+            yanchor='top'
+        ),
+        margin=dict(t=150, r=150, b=50, l=50),
+        height=PLOT_HEIGHT,
+        width=PLOT_WIDTH,
+        hovermode='x unified',
+        showlegend=True,
+        legend=dict(
+            groupclick="toggleitem",
+            yanchor="top",
+            y=0.99,
+            xanchor="left",
+            x=1.05
+        ),
+        updatemenus=updatemenus
+    )
+    
+    return fig
+
+# Add new callback for individual net contributions
+@app.callback(
+    Output('individual-net-contributions', 'figure'),
+    [Input('iteration-filter', 'value'),
+     Input('interval-component', 'n_intervals')]
+)
+def update_individual_net_contributions(iteration, n_intervals):
+    # Reload data each time
+    data = load_data()
+    filtered_data = data['agent_records'][data['agent_records']['IterationNumber'] == iteration]
+    
+    fig = go.Figure()
+    
+    # Group agents by their true team ID
+    for team_id in filtered_data['TrueSomasTeamID'].unique():
+        team_data = filtered_data[filtered_data['TrueSomasTeamID'] == team_id]
+        team_color = px.colors.qualitative.Set1[team_id % len(px.colors.qualitative.Set1)]
+        
+        # Plot each agent in the team
+        for agent_id in team_data['AgentID'].unique():
+            agent_data = team_data[team_data['AgentID'] == agent_id]
+            
+            # Find where agent dies (if it does)
+            death_point = None
+            if any(~agent_data['IsAlive']):
+                death_data = agent_data[~agent_data['IsAlive']]
+                if not death_data.empty:
+                    death_point = death_data.iloc[0]
+            
+            # Plot including the death point
+            if death_point is not None:
+                plot_data = agent_data[agent_data['TurnNumber'] <= death_point['TurnNumber']]
+            else:
+                plot_data = agent_data
+            
+            if not plot_data.empty:
+                agent_info = agent_data.iloc[0]
+                # Calculate net contribution (contribution minus withdrawal)
+                plot_data['NetContribution'] = plot_data['Contribution'] - plot_data['Withdrawal']
+                
+                # Plot net contribution line
+                fig.add_trace(go.Scatter(
+                    x=plot_data['TurnNumber'],
+                    y=plot_data['NetContribution'],
+                    name=f'T{team_id}_{agent_info["TeamID"][:4]}_{agent_id[:8]}',
+                    mode='lines',
+                    line=dict(color=team_color)
+                ))
+                
+                # Add skull emoji at death point if agent dies
+                if death_point is not None:
+                    net_at_death = death_point['Contribution'] - death_point['Withdrawal']
+                    fig.add_trace(go.Scatter(
+                        x=[death_point['TurnNumber']],
+                        y=[net_at_death],
+                        mode='text',
+                        text=['💀'],
+                        textfont=dict(size=20),
+                        showlegend=False,
+                        hoverinfo='skip'
+                    ))
+    
+    # Add a zero line for reference
+    fig.add_hline(y=0, line_dash="dash", line_color="gray", opacity=0.5)
+    
+    fig.update_layout(
+        title='Individual Agent Net Contributions Over Time',
+        xaxis_title="Turn Number",
+        yaxis_title="Net Contribution (Contribution - Withdrawal)",
+        hovermode='x unified',
+        showlegend=True,
+        legend=dict(
+            groupclick="toggleitem",
+            yanchor="top",
+            y=0.99,
+            xanchor="left",
+            x=1.05
+        ),
+        height=PLOT_HEIGHT,
+        width=PLOT_WIDTH,
+        margin=dict(t=150, r=150, b=50, l=50)
+    )
+    
+    return fig
+
+>>>>>>> Stashed changes
 # Add some CSS styling
 app.index_string = '''
 <!DOCTYPE html>


### PR DESCRIPTION
Pushed the presentation version for the visualization page
Major update includes:

1. button drop down to quickly select a specific team's data
![image](https://github.com/user-attachments/assets/1c8d72f6-02b3-473f-9edb-735753b286d9)

2. another score graph, but groups agent by the team they formed in game
![image](https://github.com/user-attachments/assets/12ebb3a0-8cff-4e57-8252-782dc4e7a0d2)

3. replaced the average contribution / withdraw of a team with individual net contribution
![image](https://github.com/user-attachments/assets/a999b98c-f3b5-4622-9810-d99554cb36eb)

also updates team 4 agent of mi_256