### PR TITLE
Feature/expose global thresholds

### DIFF
--- a/agents/Team1Agent.go
+++ b/agents/Team1Agent.go
@@ -3,6 +3,7 @@ package agents
 import (
 	// "fmt"
 	"log"
+	"math"
 
 	"github.com/google/uuid"
 
@@ -132,6 +133,14 @@ func (a1 *Team1Agent) GetActualWithdrawal(instance common.IExtendedAgent) int {
 		commonPool := a1.Server.GetTeam(a1.GetID()).GetCommonPool()
 		aoaExpectedWithdrawal := a1.Server.GetTeam(a1.GetID()).TeamAoA.GetExpectedWithdrawal(a1.GetID(), a1.Score, commonPool)
 		currentRank := 0
+
+		/* If the threshold is known (this only occurs in some games), then just
+		   withdraw the minimum you need to survive. */
+		knownThreshold, ok := a1.Server.GetTeam(a1.GetID()).GetKnownThreshold()
+		if ok {
+			return int(math.Max(float64(knownThreshold)-float64(a1.Score), 0.0))
+		}
+
 		switch a1.agentType {
 		case Honest:
 			return aoaExpectedWithdrawal

--- a/common/team.go
+++ b/common/team.go
@@ -63,7 +63,7 @@ func (team *Team) InvalidateThreshold() {
 }
 
 // Return the known threshold and the flag that determines if its valid or not
-func (team *Team) GetKnownThreshold(threshold int) (int, bool) {
+func (team *Team) GetKnownThreshold() (int, bool) {
 	return team.knownThreshold, team.validThreshold
 }
 

--- a/common/team.go
+++ b/common/team.go
@@ -9,11 +9,13 @@ import (
 )
 
 type Team struct {
-	TeamID     uuid.UUID
-	Agents     []uuid.UUID
-	TeamAoA    IArticlesOfAssociation
-	TeamAoAID  int
-	commonPool int
+	TeamID         uuid.UUID
+	Agents         []uuid.UUID
+	TeamAoA        IArticlesOfAssociation
+	TeamAoAID      int
+	commonPool     int
+	knownThreshold int  // current threshold set by server
+	validThreshold bool // flag if the threshold has been updated this turn
 }
 
 func (team *Team) GetCommonPool() int {
@@ -42,6 +44,27 @@ func NewTeam(teamID uuid.UUID) *Team {
 		Agents:     []uuid.UUID{}, // Initialize an empty slice of agent UUIDs
 		TeamAoA:    teamAoA,       // Initialize strategy as 0
 	}
+}
+
+/**
+* Set the known threshold so that agents can adapt their behaviour based on
+* this. AGENTS PLEASE DON'T CALL THIS - in an ideal world we would use
+* pre-signed certificates to know that only the server updated this but our
+* code is not prioritising security.
+ */
+func (team *Team) SetKnownThreshold(threshold int) {
+	team.knownThreshold = threshold
+	team.validThreshold = true
+}
+
+// Same as above, @agents please don't call this
+func (team *Team) InvalidateThreshold() {
+	team.validThreshold = false
+}
+
+// Return the known threshold and the flag that determines if its valid or not
+func (team *Team) GetKnownThreshold(threshold int) (int, bool) {
+	return team.knownThreshold, team.validThreshold
 }
 
 // --------- Recording Functions ---------

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"io"
 	"log"
 	"os"
@@ -47,6 +48,9 @@ func main() {
 		VerboseLevel: 10,
 	}
 
+	argExposeThresholds := flag.Bool("exposeThresholds", false, "Expose the thresholds to the agents")
+	flag.Parse()
+
 	serv := &envServer.EnvironmentServer{
 		// note: the zero turn is used for team forming
 		BaseServer: baseServer.CreateBaseServer[common.IExtendedAgent](
@@ -57,7 +61,8 @@ func main() {
 		Teams: make(map[uuid.UUID]*common.Team),
 	}
 	serv.Init(
-		3, // turns to apply threshold once
+		3,                    // turns to apply threshold once
+		*argExposeThresholds, // expose thresholds
 	)
 	serv.SetGameRunner(serv)
 

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -36,6 +36,9 @@ type EnvironmentServer struct {
 	thresholdTurns         int
 	thresholdAppliedInTurn bool
 	allAgentsDead          bool
+
+	// game config parameters :D
+	exposeThresholds bool // expose current threshold to agents
 }
 
 func init() {
@@ -354,10 +357,21 @@ func (cs *EnvironmentServer) RunTurn(i, j int) {
 	// Attempt to allocate the orphans to their preferred teams
 	cs.AllocateOrphans()
 
-	cs.turn = j
+	cs.turn = j // set the turn
+
+	// Invalidate known thresholds in all teams
+	for _, team := range cs.Teams {
+		team.InvalidateThreshold()
+	}
+
+	// If and only if exposeThresholds is true, expose to agents
+    if cs.exposeThresholds {
+        for _, team := range cs.Teams {
+            team.SetKnownThreshold(cs.roundScoreThreshold)
+        }
+    }
 
 	cs.teamsMutex.Lock()
-	// defer cs.teamsMutex.Unlock()
 
 	for _, team := range cs.Teams {
 		if len(team.Agents) == 0 {
@@ -372,12 +386,8 @@ func (cs *EnvironmentServer) RunTurn(i, j int) {
 			cs.RunTurnTeam5(team)
 		default:
 			cs.RunTurnDefault(team)
-
 		}
-
 	}
-
-	// TODO: Reallocate agents who left their teams during the turn
 
 	// check if threshold turn
 
@@ -1163,4 +1173,13 @@ func (cs *EnvironmentServer) GetTeamsByAoA(aoa int) []common.Team {
 		}
 	}
 	return teams
+}
+
+/**
+* Update the Global Known Threshold for each team.
+ */
+func (cs *EnvironmentServer) UpdateKnownThresholds() {
+	for _, team := range cs.Teams {
+		team.SetKnownThreshold(cs.roundScoreThreshold)
+	}
 }

--- a/server/EnvironmentServer.go
+++ b/server/EnvironmentServer.go
@@ -365,11 +365,11 @@ func (cs *EnvironmentServer) RunTurn(i, j int) {
 	}
 
 	// If and only if exposeThresholds is true, expose to agents
-    if cs.exposeThresholds {
-        for _, team := range cs.Teams {
-            team.SetKnownThreshold(cs.roundScoreThreshold)
-        }
-    }
+	if cs.exposeThresholds {
+		for _, team := range cs.Teams {
+			team.SetKnownThreshold(cs.roundScoreThreshold)
+		}
+	}
 
 	cs.teamsMutex.Lock()
 
@@ -646,9 +646,10 @@ func (cs *EnvironmentServer) Start() {
 }
 
 // custom init that gets called earlier
-func (cs *EnvironmentServer) Init(turnsForThreshold int) {
+func (cs *EnvironmentServer) Init(turnsForThreshold int, exposeThresholds bool) {
 	cs.DataRecorder = gameRecorder.CreateRecorder()
 	cs.thresholdTurns = turnsForThreshold
+	cs.exposeThresholds = exposeThresholds
 }
 
 func (cs *EnvironmentServer) reviveDeadAgents() {


### PR DESCRIPTION
You can now expose global thresholds to agents by running: 

```
go run . --exposeThresholds
```

At the minute, team1 agent will just take the minimum amount needed to survive in this case. 